### PR TITLE
Fix Zp subtract (now uses one MOD instead of two)

### DIFF
--- a/src/main/java/de/upb/crypto/math/structures/zn/Zn.java
+++ b/src/main/java/de/upb/crypto/math/structures/zn/Zn.java
@@ -125,6 +125,11 @@ public class Zn implements Ring {
         public ZnElement neg() {
             return createZnElement(v.negate());
         }
+    
+        @Override
+        public ZnElement sub(Element e) {
+            return createZnElement(v.subtract(((ZnElement)e).v));
+        }
 
         @Override
         public ZnElement mul(Element e) {

--- a/src/main/java/de/upb/crypto/math/structures/zn/Zp.java
+++ b/src/main/java/de/upb/crypto/math/structures/zn/Zp.java
@@ -93,6 +93,11 @@ public class Zp extends Zn implements Field {
         public ZpElement add(Element e) {
             return (ZpElement) super.add(e);
         }
+    
+        @Override
+        public ZpElement sub(Element e) {
+            return (ZpElement) super.sub(e);
+        }
 
         @Override
         public ZpElement neg() {


### PR DESCRIPTION
Jan said this should get merged into master. It significantly improves the performance of subtracting two ZpElements