### PR TITLE
Added v2 annotation-based serialization framework

### DIFF
--- a/src/main/java/de/upb/crypto/math/interfaces/structures/Group.java
+++ b/src/main/java/de/upb/crypto/math/interfaces/structures/Group.java
@@ -1,7 +1,9 @@
 package de.upb.crypto.math.interfaces.structures;
 
 import de.upb.crypto.math.serialization.Representation;
+import de.upb.crypto.math.serialization.annotations.v2.RepresentationRestorer;
 
+import java.lang.reflect.Type;
 import java.math.BigInteger;
 import java.util.List;
 import java.util.Map;
@@ -11,7 +13,7 @@ import java.util.concurrent.Executors;
 /**
  * A Group. Operations are defined on its elements.
  */
-public interface Group extends Structure {
+public interface Group extends Structure, RepresentationRestorer {
     /**
      * Thread pool used for concurrent evaluation of multiple PowProductExpressions
      */
@@ -140,5 +142,13 @@ public interface Group extends Structure {
      */
     default PowProductExpression powProductExpression() {
         return new PowProductExpression(this);
+    }
+
+    @Override
+    default GroupElement recreateFromRepresentation(Type type, Representation repr) {
+        if (!(type instanceof Class && GroupElement.class.isAssignableFrom((Class) type)))
+            throw new IllegalArgumentException("Group cannot recreate type "+type.getTypeName()+" from representation");
+
+        return getElement(repr);
     }
 }

--- a/src/main/java/de/upb/crypto/math/interfaces/structures/Ring.java
+++ b/src/main/java/de/upb/crypto/math/interfaces/structures/Ring.java
@@ -1,7 +1,9 @@
 package de.upb.crypto.math.interfaces.structures;
 
 import de.upb.crypto.math.serialization.Representation;
+import de.upb.crypto.math.serialization.annotations.v2.RepresentationRestorer;
 
+import java.lang.reflect.Type;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -12,7 +14,7 @@ import java.util.List;
  * A Ring (with 1).
  * Operations are defined on its elements.
  */
-public interface Ring extends Structure {
+public interface Ring extends Structure, RepresentationRestorer {
     /**
      * Returns an object representing the additive group of this ring
      */
@@ -47,6 +49,14 @@ public interface Ring extends Structure {
 
     @Override
     RingElement getElement(Representation repr);
+
+    @Override
+    default RingElement recreateFromRepresentation(Type type, Representation repr) {
+        if (!(type instanceof Class && RingElement.class.isAssignableFrom((Class) type)))
+            throw new IllegalArgumentException("Ring cannot recreate type "+type.getTypeName()+" from representation");
+
+        return getElement(repr);
+    }
 
     @Override
     RingElement getUniformlyRandomElement() throws UnsupportedOperationException;

--- a/src/main/java/de/upb/crypto/math/interfaces/structures/RingGroup.java
+++ b/src/main/java/de/upb/crypto/math/interfaces/structures/RingGroup.java
@@ -1,10 +1,7 @@
 package de.upb.crypto.math.interfaces.structures;
 
-import de.upb.crypto.math.serialization.ObjectRepresentation;
+import de.upb.crypto.math.serialization.RepresentableRepresentation;
 import de.upb.crypto.math.serialization.Representation;
-import de.upb.crypto.math.serialization.StringRepresentation;
-import de.upb.crypto.math.serialization.util.RepresentationToJavaObjectHelper;
-
 /**
  * Common base class for ring subgroups (additive/unit groups)
  */
@@ -21,8 +18,7 @@ public abstract class RingGroup implements Group {
     }
 
     public RingGroup(Representation repr) {
-        ObjectRepresentation r = (ObjectRepresentation) repr;
-        ring = (Ring) RepresentationToJavaObjectHelper.getInstance().getObject(((StringRepresentation) r.get("ringTypeName")).get(), r.get("ringRepresentation"));
+        ring = (Ring) repr.repr().recreateRepresentable();
     }
 
     @Override
@@ -37,10 +33,7 @@ public abstract class RingGroup implements Group {
 
     @Override
     public Representation getRepresentation() {
-        ObjectRepresentation result = new ObjectRepresentation();
-        result.put("ringTypeName", new StringRepresentation(ring.getRepresentedTypeName()));
-        result.put("ringRepresentation", ring.getRepresentation());
-        return result;
+        return new RepresentableRepresentation(ring);
     }
 
     public Ring getRing() {

--- a/src/main/java/de/upb/crypto/math/serialization/Representable.java
+++ b/src/main/java/de/upb/crypto/math/serialization/Representable.java
@@ -8,26 +8,25 @@ package de.upb.crypto.math.serialization;
  * A special case of Representable is StandaloneRepresentable, which allows recreating the Representable through a
  * standard interface
  * (NOT-standalone Representables may need some specific non-standard means of recreating, e.g., Elements of
- * Structures via structure.getElement(repr)).
+ * Structures via structure.getElement(repr)). This also ensures that the resulting object belongs to the expected group.
  */
 public interface Representable {
     /**
      * A String, uniquely identifying the kind of object encoded in the representation (not the object itself).
      * By convention, this is the fully qualified class name of the object.
-     * If you change this, it will break the default handler in RepresentationToJavaObjectHelper and you will have to
-     * add your special case to its code.
+     * @Deprecated not needed: has never been overwritten and is not used anywhere anymore. Will be removed in next major release.
      */
+    @Deprecated
     default String getRepresentedTypeName() {
         return this.getClass().getName();
     }
 
     /**
-     * The representation of this object. Used for serialization
+     * The representation of this object. Used for serialization.
+     * A convenient way to implement this is using @link {@link de.upb.crypto.math.serialization.annotations.v2.ReprUtil}
      *
-     * @return a Representation or null if the representedTypeName suffices to instantiate an equal object again
+     * @return a Representation or null if an equal object can be recreated without any information.
      * @see Representation
      */
     Representation getRepresentation();
-
-
 }

--- a/src/main/java/de/upb/crypto/math/serialization/RepresentableRepresentation.java
+++ b/src/main/java/de/upb/crypto/math/serialization/RepresentableRepresentation.java
@@ -1,6 +1,6 @@
 package de.upb.crypto.math.serialization;
 
-import de.upb.crypto.math.serialization.util.RepresentationToJavaObjectHelper;
+import java.lang.reflect.InvocationTargetException;
 
 /**
  * A Representation that saves a (getRepresentedTypeName(), getRepresentation()) tuple.
@@ -13,7 +13,7 @@ public class RepresentableRepresentation extends Representation {
     protected final Representation representation;
 
     public RepresentableRepresentation(Representable r) {
-        representedTypeName = r.getRepresentedTypeName();
+        representedTypeName = r.getClass().getName();
         representation = r.getRepresentation();
     }
 
@@ -40,7 +40,27 @@ public class RepresentableRepresentation extends Representation {
      * to try to recreate the Representable that is represented here.
      */
     public Object recreateRepresentable() {
-        return RepresentationToJavaObjectHelper.getInstance().getObject(representedTypeName, representation);
+        switch (representedTypeName) {
+            default: //default case: try some reflection magic (i.e. try to interpret representedTypeName as fully qualified class name, call constructor with Representation argument)
+                try {
+                    Class<?> c = Class.forName(representedTypeName);
+                    try {
+                        if (c.isEnum()) {
+                            return Enum.valueOf((Class<? extends Enum>) c, representation.str().get());
+                        }
+                        return c.getConstructor(Representation.class).newInstance(representation);
+                    } catch (NoSuchMethodException e) { //no constructor with single Representation paramenter
+                        if (representation == null) //no representation necessary. Try default constructor
+                            return c.getConstructor(new Class<?>[]{}).newInstance();
+                        else
+                            throw e;
+                    }
+                } catch (ClassNotFoundException e) {
+                    throw new IllegalArgumentException("Cannot find class " + representedTypeName, e);
+                } catch (NoSuchMethodException | SecurityException | InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+                    throw new IllegalArgumentException("Don't know how to handle Representable type '" + representedTypeName + "'", e);
+                }
+        }
     }
 
     @Override

--- a/src/main/java/de/upb/crypto/math/serialization/annotations/Represented.java
+++ b/src/main/java/de/upb/crypto/math/serialization/annotations/Represented.java
@@ -13,6 +13,7 @@ import java.lang.annotation.Target;
  */
 @Retention(value = RetentionPolicy.RUNTIME)
 @Target(value = ElementType.FIELD)
+@Deprecated //planning deleation. Superseded by the de.upb.crypto.math.serialization.annotation.v2 framework.
 public @interface Represented {
     String recoveryMethod() default "";
 

--- a/src/main/java/de/upb/crypto/math/serialization/annotations/v2/CustomRepresentationRestorer.java
+++ b/src/main/java/de/upb/crypto/math/serialization/annotations/v2/CustomRepresentationRestorer.java
@@ -1,0 +1,19 @@
+package de.upb.crypto.math.serialization.annotations.v2;
+
+import de.upb.crypto.math.serialization.Representation;
+
+import java.lang.reflect.Type;
+import java.util.function.Function;
+
+public class CustomRepresentationRestorer implements RepresentationRestorer {
+    protected final Function<? super Representation, ?> restorer;
+
+    public CustomRepresentationRestorer(Function<? super Representation, ?> restorer) {
+        this.restorer = restorer;
+    }
+
+    @Override
+    public Object recreateFromRepresentation(Type type, Representation repr) {
+        return restorer.apply(repr);
+    }
+}

--- a/src/main/java/de/upb/crypto/math/serialization/annotations/v2/ReprUtil.java
+++ b/src/main/java/de/upb/crypto/math/serialization/annotations/v2/ReprUtil.java
@@ -1,0 +1,304 @@
+package de.upb.crypto.math.serialization.annotations.v2;
+
+import de.upb.crypto.math.factory.BilinearGroup;
+import de.upb.crypto.math.serialization.*;
+import de.upb.crypto.math.serialization.annotations.v2.internal.*;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+/**
+ * Allows for easy Representation handling.
+ *
+ * Typical usage example:
+ * - Your class is StandaloneRepresentable, i.e. you need to give a constructor with Representation argument and a getRepresentation() method.
+ * - In your class, annotate all fields that need to be part of the Representation with @Represented. (e.g., @Represented private Group group)
+ * - If some objects need help being deserialized (e.g., GroupElements are deserialized by their group), define a restorer in the @Represented annotation,
+ *   e.g., @Represented(restorer="group") private GroupElement x;
+ *   The restorer can either be another field of your class (like group in the example above), or another handler, which you'd have to register using {@link ReprUtil#register(RepresentationRestorer, String)}.
+ * - In the constructor(Representation repr), call: new ReprUtil(this).deserialize(repr);
+ * - In getRepresentation(), call ReprUtil.serialize(this);
+ *
+ * - The framework can handle Lists, Sets, and Maps as well. For example, @Represented(restorer="[group]") handles a list or set of group elements
+ *   and @Represented(restorer="String -> [group]") handles a map of Strings to lists of group elements.
+ *   Check {@link Represented#restorer()} for details.
+ * - Example with additional information: Suppose your object depends on public parameters (e.g., a publicly known bilinear group bilGroup, consisting of groups G1, G2, GT).
+ *   You'd annotate GroupElement members
+ *   with @Annotated(restorer="G1"), @Annotated(restorer="G2"), @Annotated(restorer="GT"), depending on which of the three groups each of them belongs to.
+ *   Your constructor would take these public parameters pp and a Representation repr as input and then call new ReprUtil(this).register(bilGroup).deserialize(repr);
+ *   getRepresentation() would still just call ReprUtil.serialize(this);
+ */
+public class ReprUtil {
+    /**
+     * RepresentationRestorer that can help during recreation of the instance.
+     */
+    protected HashMap<String, RepresentationRestorer> restorers = new HashMap<>();
+
+    /**
+     * Object that's subject to represent or be recreated from Representation.
+     */
+    protected Object instance;
+
+    /**
+     * Create ReprUtil for a specific instance.
+     */
+    public ReprUtil(Object instance) {
+        this.instance = instance;
+    }
+
+    /**
+     * Register a restorer for a Representation (usually, interfaces with a "recreateFoo(Representation)" method should be
+     * valid arguments).
+     * Annotate the field that should use this with @Represented(restorer = "name")
+     *
+     * @param restorer a class that knows how to restore values from Representation (e.g., a Group knows how to restore its GroupElements)
+     * @param name the name for this restorer (same as in the @Represented annotation)
+     * @return this. For chaining.
+     */
+    public ReprUtil register(RepresentationRestorer restorer, String name) {
+        if (restorers.containsKey(name))
+            throw new IllegalArgumentException("Already used name "+name);
+
+        if (Stream.of("->", ",", "[", "]", " ").anyMatch(name::contains))
+            throw new IllegalArgumentException("Restorer name "+name+" contains reserved chars");
+
+        restorers.put(name, restorer);
+        return this;
+    }
+
+    public ReprUtil register(BilinearGroup bilinearGroup) {
+        register(bilinearGroup.getG1(), "G1");
+        register(bilinearGroup.getG2(), "G2");
+        register(bilinearGroup.getGT(), "GT");
+        return this;
+    }
+
+    /**
+     * Register a custom restorer function, which takes a Representation and recreates the object.
+     * Annotate the field that should use this with @Represented(restorer = "name")
+     * You should usually not need this (prefer register(RepresentationRestorer))
+     *
+     * @param restorer a function taking a Representation and restoring the corresponding object.
+     * @param name the name for this restorer function (same as in the @Represented annotation)
+     * @return this. For chaining.
+     */
+    public ReprUtil register(Function<? super Representation, ?> restorer, String name)  {
+        return this.register(new CustomRepresentationRestorer(restorer), name);
+    }
+
+    /**
+     * Iterates over all fields of instance's class and its superclasses, making them accessible (readable, writable) for the fieldConsumer call.
+     */
+    private void forEachField(Consumer<Field> fieldConsumer) {
+        Class<?> clazz = instance.getClass();
+        while (!clazz.equals(Object.class)) {
+            try {
+                Field[] fields = clazz.getDeclaredFields();
+                for (Field field : fields) {
+                    if (hasRepresentedTypeAnnotation(field)) {
+                        field.setAccessible(true); //TODO need to reset this to false or it was before?!
+                        fieldConsumer.accept(field);
+                    }
+                }
+            } catch (SecurityException | IllegalArgumentException e) {
+                throw new RuntimeException(e);
+            } finally {
+                clazz = clazz.getSuperclass();
+            }
+        }
+    }
+
+    /**
+     * Private helper method: given field name, outputs corresponding Field for instance.
+     */
+    private Field getFieldByName(String name) {
+        Class<?> clazz = instance.getClass();
+        while (!clazz.equals(Object.class)) {
+            try {
+                Field field = clazz.getDeclaredField(name);
+                return field;
+            } catch (SecurityException | IllegalArgumentException e) {
+                throw new RuntimeException(e);
+            } catch (NoSuchFieldException e) {
+                //That's expected. Just use the superclass then
+            } finally {
+                clazz = clazz.getSuperclass();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Takes the instance and represents it as a Representation.
+     * @return a Representation
+     */
+    public Representation serialize() {
+        ObjectRepresentation result = new ObjectRepresentation();
+        forEachField(field -> {
+            try {
+                result.put(field.getName(), getHandler(field.getGenericType(), getRestorerStringOfField(field)).serializeToRepresentation(field.get(instance)));
+            } catch (IllegalAccessException e) {
+                throw new RuntimeException(e);
+            }
+        });
+        return result;
+    }
+
+    /**
+     * Takes the instance and represents it as a Representation.
+     * @param instance the object to serialize
+     * @return a Representation
+     */
+    public static Representation serialize(Object instance) {
+        return new ReprUtil(instance).serialize();
+    }
+
+    /**
+     * Recreates the instance from representation.
+     * @param repr a Representation you got from serialize()
+     */
+    public void deserialize(Representation repr) {
+        forEachField(field -> restoreField(field, repr));
+    }
+
+    /**
+     * Handles a single field of instance.
+     * @param field what field of instance to handle
+     * @param topLevelRepr the representation for instance
+     * @return the value assigned to the field.
+     */
+    Object restoreField(Field field, Representation topLevelRepr) {
+        try {
+            Object value = field.get(instance);
+            if (value != null)
+                return value;
+
+            value = getHandlerForField(field).deserializeFromRepresentation(topLevelRepr.obj().get(field.getName()), name -> getOrRecreateRestorer(name, topLevelRepr));
+            field.set(instance, value);
+            return value;
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Gets restorer from registered restorers or - if it's not there - look for it within the fields instance's class
+     * (and restore it if annotated).
+     */
+    RepresentationRestorer getOrRecreateRestorer(String name, Representation topLevelRepr) {
+        if (restorers.containsKey(name))
+            return restorers.get(name);
+
+        //Restorer is some field
+        Field field = getFieldByName(name);
+        if (field == null)
+            throw new IllegalArgumentException("\""+name+"\" is neither the name of a restorer given through ReprUtil.register, nor is it a member of the class being recreated.");
+
+        Object result = restoreField(field, topLevelRepr);
+
+        if (result == null)
+            throw new NullPointerException("The member \""+name+"\" is null and hence cannot be used to recreate further objects from representation");
+
+        if (!(result instanceof RepresentationRestorer))
+            throw new IllegalArgumentException("\""+name+"\" is the name of a member of your class, but its value does not seem to implement the RepresentationRestorer interface.");
+
+        return (RepresentationRestorer) result;
+    }
+
+    /**
+     * Helper method. Checks whether field is annotated.
+     */
+    private static boolean hasRepresentedTypeAnnotation(Field field) {
+        Annotation[] annotations = field.getDeclaredAnnotations();
+        if (annotations == null || annotations.length == 0) {
+            return false;
+        }
+        return Arrays.stream(annotations)
+                .map(Annotation::annotationType)
+                .anyMatch(a -> a.getSimpleName().startsWith("Represented"));
+    }
+
+    /**
+     * Helper method.
+     * If field is annotated with @Represented annotation, returns the annotation's "restorer" value.
+     */
+    private static String getRestorerStringOfField(Field field) {
+        Annotation[] annotations = field.getDeclaredAnnotations();
+        if (annotations == null || annotations.length == 0)
+            return null;
+
+        for (Annotation annotation : annotations)
+            if (annotation.annotationType().equals(Represented.class))
+                return ((Represented) annotation).restorer();
+
+        return null;
+    }
+
+    protected static RepresentationHandler getHandlerForField(Field field) {
+        return getHandler(field.getGenericType(), getRestorerStringOfField(field));
+    }
+
+    /**
+     * Derives the ReputationHandler for a certain Type (and restorerString).
+     * This is done statically, i.e. with static type information.
+     */
+    protected static RepresentationHandler getHandler(Type type, String restorerString) {
+        if (StandaloneRepresentationHandler.canHandle(type))
+            return new StandaloneRepresentationHandler((Class) type);
+
+        if (DependentRepresentationHandler.canHandle(type))
+            return new DependentRepresentationHandler(restorerString, type);
+
+        String trimmedString = restorerString.trim();
+        if (ListAndSetRepresentationHandler.canHandle(type) && trimmedString.startsWith("[") && trimmedString.endsWith("]")) {
+            Type elementType = ListAndSetRepresentationHandler.getElementType(type);
+            return new ListAndSetRepresentationHandler(getHandler(elementType, trimmedString.substring(1, trimmedString.length()-1)), type);
+        }
+
+        if (ArrayRepresentationHandler.canHandle(type) && trimmedString.startsWith("[") && trimmedString.endsWith("]")) {
+            Type elementType = ArrayRepresentationHandler.getTypeOfElements(type);
+            return new ArrayRepresentationHandler(getHandler(elementType, trimmedString.substring(1, trimmedString.length()-1)), type);
+        }
+
+        int mapArrowIndex = findMapArrow(trimmedString);
+        if (MapRepresentationHandler.canHandle(type) && mapArrowIndex != -1) {
+            Type keyType = MapRepresentationHandler.getKeyType(type);
+            Type valueType = MapRepresentationHandler.getValueType(type);
+            return new MapRepresentationHandler(getHandler(keyType, trimmedString.substring(0, mapArrowIndex)),
+                    getHandler(valueType, trimmedString.substring(mapArrowIndex+2)),
+                    type);
+        }
+
+        throw new IllegalArgumentException("Don't know how to handle type "+type.getTypeName()+" using restorer String \""+restorerString+"\"");
+    }
+
+    /**
+     * Helper method.
+     * Returns the index of the top-level "->" within the given String (the index of '-' char, to be precise).
+     * If none, returns -1.
+     */
+    private static int findMapArrow(String str) {
+        int depth = 0; //number of "[" read minus number of "]" read.
+        for (int i=0;i<str.length();i++) {
+            switch (str.charAt(i)) {
+                case '[':
+                    depth++;
+                    break;
+                case ']':
+                    depth--;
+                    break;
+                case '-':
+                    if (depth == 0 && str.length() > i+1 && str.charAt(i+1) == '>') //detected map that's not nested in []
+                        return i;
+                    break;
+            }
+        }
+        return -1;
+    }
+}

--- a/src/main/java/de/upb/crypto/math/serialization/annotations/v2/RepresentationRestorer.java
+++ b/src/main/java/de/upb/crypto/math/serialization/annotations/v2/RepresentationRestorer.java
@@ -1,0 +1,22 @@
+package de.upb.crypto.math.serialization.annotations.v2;
+
+import de.upb.crypto.math.serialization.Representation;
+
+import java.lang.reflect.Type;
+
+/**
+ * This class handles (recreation from) representation for some related classes
+ * (e.g., a Group handles recreation of group elements from their representation).
+ *
+ * There is usually no need to override this (it should be a default method in whatever interface this is relevant for, e.g., Group).
+ */
+public interface RepresentationRestorer {
+    /**
+     * Takes a Representation and creates an Object of the given type from it.
+     * @param type serves as an indicator on what type the Representation is supposed to be unpacked to.
+     * @param repr the Representation to restore the object from.
+     * @return the recreated object.
+     * @throws IllegalArgumentException if unable to return the required type.
+     */
+    Object recreateFromRepresentation(Type type, Representation repr);
+}

--- a/src/main/java/de/upb/crypto/math/serialization/annotations/v2/Represented.java
+++ b/src/main/java/de/upb/crypto/math/serialization/annotations/v2/Represented.java
@@ -1,0 +1,31 @@
+package de.upb.crypto.math.serialization.annotations.v2;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(value = RetentionPolicy.RUNTIME)
+@Target(value = ElementType.FIELD)
+/**
+ * Part of the framework to simplify serialization and deserialization of objects.
+ * Add this annotation to all fields that need to be part of the object's Representation.
+ * Then use ReprUtil to automatically serialize and deserialize your object according to these annotations.
+ * @see ReprUtil
+ */
+public @interface Represented {
+    /**
+     * The handler for the annotated field (corresponds to a name you put into ReprUtil.register or a field name in your class).
+     * Usually, this is just a name like "G1", meaning that the serialization and deserialization of this field should be handled by "G1".
+     *
+     * If this is a Collection or a Map field, the restorer String must explain how to restore its elements.
+     * For example, for a list/set whose elements should be deserialized by G1, you'd write "[G1]" (i.e. a list of G1 elements).
+     * For a map, whose keys are handled by G1 and whose values by G2, write "G1 -> G2".
+     *
+     * These can be combined, e.g., "G1 -> [[G2]]" for a map whose keys are handled by G1 and whose values are lists of lists of G2.
+     *
+     * If the type is simple (i.e. StandaloneRepresentable, BigInteger, Integer, String, Boolean, or byte[]), this value is ignored.
+     * This is again true for nested expressions, e.g., "FOO -> G2" works for a Map from String to GroupElement, as the String "FOO" is simply ignored.
+     */
+    String restorer() default "";
+}

--- a/src/main/java/de/upb/crypto/math/serialization/annotations/v2/internal/ArrayRepresentationHandler.java
+++ b/src/main/java/de/upb/crypto/math/serialization/annotations/v2/internal/ArrayRepresentationHandler.java
@@ -1,0 +1,57 @@
+package de.upb.crypto.math.serialization.annotations.v2.internal;
+
+import de.upb.crypto.math.serialization.ListRepresentation;
+import de.upb.crypto.math.serialization.Representation;
+import de.upb.crypto.math.serialization.annotations.v2.RepresentationRestorer;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.Type;
+import java.util.function.Function;
+
+public class ArrayRepresentationHandler implements RepresentationHandler {
+    protected RepresentationHandler elementHandler;
+    protected Class elementType;
+
+    public ArrayRepresentationHandler(RepresentationHandler elementHandler, Type typeofArray) {
+        this.elementHandler = elementHandler;
+        this.elementType = getTypeOfElements(typeofArray);
+    }
+
+    public static Class getTypeOfElements(Type typeOfArray) {
+        return ((Class) typeOfArray).getComponentType();
+    }
+
+    public static boolean canHandle(Type type) {
+        if (!(type instanceof Class))
+            return false;
+
+        Class arrayType = (Class) type;
+        if (!arrayType.isArray())
+            return false;
+
+        return true;
+    }
+
+    @Override
+    public Object deserializeFromRepresentation(Representation repr, Function<String, RepresentationRestorer> getRegisteredRestorer) {
+        //Create array
+        Object result = Array.newInstance(elementType, repr.list().size());
+
+        //Restore elements
+        int i=0;
+        for (Representation inner : repr.list())
+            Array.set(result, i++, elementHandler.deserializeFromRepresentation(inner, getRegisteredRestorer));
+
+        return result;
+    }
+
+    @Override
+    public Representation serializeToRepresentation(Object obj) {
+        ListRepresentation repr = new ListRepresentation();
+
+        for (int i=0; i<Array.getLength(obj); i++)
+            repr.put(elementHandler.serializeToRepresentation(Array.get(obj, i)));
+
+        return repr;
+    }
+}

--- a/src/main/java/de/upb/crypto/math/serialization/annotations/v2/internal/DependentRepresentationHandler.java
+++ b/src/main/java/de/upb/crypto/math/serialization/annotations/v2/internal/DependentRepresentationHandler.java
@@ -1,0 +1,35 @@
+package de.upb.crypto.math.serialization.annotations.v2.internal;
+
+import de.upb.crypto.math.serialization.Representable;
+import de.upb.crypto.math.serialization.Representation;
+import de.upb.crypto.math.serialization.annotations.v2.RepresentationRestorer;
+
+import java.lang.reflect.Type;
+import java.util.function.Function;
+
+/**
+ * Handles representations that depend on some RepresentationRestorer in order to be recreated.
+ */
+public class DependentRepresentationHandler implements RepresentationHandler {
+    protected String restorerName;
+    protected Type typeToRestore;
+
+    public DependentRepresentationHandler(String restorerName, Type typeToRestore) {
+        this.restorerName = restorerName;
+        this.typeToRestore = typeToRestore;
+    }
+
+    public static boolean canHandle(Type type) {
+        return type instanceof Class && Representable.class.isAssignableFrom((Class) type);
+    }
+
+    @Override
+    public Object deserializeFromRepresentation(Representation repr, Function<String, RepresentationRestorer> getRegisteredRestorer) {
+        return getRegisteredRestorer.apply(restorerName).recreateFromRepresentation(typeToRestore, repr);
+    }
+
+    @Override
+    public Representation serializeToRepresentation(Object object) {
+        return ((Representable) object).getRepresentation();
+    }
+}

--- a/src/main/java/de/upb/crypto/math/serialization/annotations/v2/internal/ListAndSetRepresentationHandler.java
+++ b/src/main/java/de/upb/crypto/math/serialization/annotations/v2/internal/ListAndSetRepresentationHandler.java
@@ -1,0 +1,97 @@
+package de.upb.crypto.math.serialization.annotations.v2.internal;
+
+import de.upb.crypto.math.serialization.ListRepresentation;
+import de.upb.crypto.math.serialization.Representation;
+import de.upb.crypto.math.serialization.annotations.v2.RepresentationRestorer;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.*;
+import java.util.function.Function;
+
+public class ListAndSetRepresentationHandler implements RepresentationHandler {
+    private static final Class[] supportedFallbackClasses = new Class[] {ArrayList.class, HashSet.class};
+    protected RepresentationHandler elementHandler;
+    protected Class collectionType;
+    protected Type elementType;
+
+    public ListAndSetRepresentationHandler(RepresentationHandler elementHandler, Type collectionType) {
+        this.elementHandler = elementHandler;
+        this.collectionType = (Class) ((ParameterizedType) collectionType).getRawType();
+        this.elementType = getElementType(collectionType);
+    }
+
+    public static Type getElementType(Type collectionType) {
+        Type[] typeArguments = ((ParameterizedType) collectionType).getActualTypeArguments();
+        if (typeArguments.length != 1) {
+            throw new IllegalArgumentException("Cannot handle collections with more than one generic type");
+        }
+        return typeArguments[0];
+    }
+
+    public static boolean canHandle(Type collectionType) { //handles List|Set<anything>.
+        if (!(collectionType instanceof ParameterizedType))
+            return false;
+
+        Type rawType = ((ParameterizedType) collectionType).getRawType();
+
+        if (!(rawType instanceof Class))
+            return false;
+
+        if (!List.class.isAssignableFrom((Class) rawType) && !Set.class.isAssignableFrom((Class) rawType))
+            return false;
+
+        try { //Check if generic type argument is okay
+            getElementType(collectionType);
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+
+        //Check if the collection has a default constructor or is an interface.
+        try {
+            ((Class) rawType).getConstructor();
+        } catch (NoSuchMethodException e) {
+            return ((Class) rawType).isInterface() && Arrays.stream(supportedFallbackClasses).anyMatch(fallback -> ((Class) rawType).isAssignableFrom(fallback));
+        }
+
+        return true;
+    }
+
+    @Override
+    public Object deserializeFromRepresentation(Representation repr, Function<String, RepresentationRestorer> getRegisteredRestorer) {
+        Collection result = null;
+
+        //Try to call default constructor to create collection.
+        try {
+            result = (Collection) collectionType.getConstructor().newInstance();
+        } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) { //fall back to ArrayList (e.g., if the field type is just List<>)
+            for (Class fallback : supportedFallbackClasses) {
+                try {
+                    if (collectionType.isAssignableFrom(fallback))
+                        result = (Collection) fallback.getConstructor().newInstance();
+                } catch (InstantiationException | NoSuchMethodException | IllegalAccessException | InvocationTargetException ex) {
+                    throw new RuntimeException("Cannot instantiate type "+collectionType.getName());
+                }
+            }
+        }
+        if (result == null)
+            throw new RuntimeException("Cannot instantiate type "+collectionType.getName());
+
+        //Restore elements
+        for (Representation inner : repr.list())
+            result.add(elementHandler.deserializeFromRepresentation(inner, getRegisteredRestorer));
+
+        return result;
+    }
+
+    @Override
+    public Representation serializeToRepresentation(Object obj) {
+        if (!(obj instanceof List || obj instanceof Set))
+            throw new IllegalArgumentException("Cannot handle representation of "+obj.getClass().getName());
+        ListRepresentation repr = new ListRepresentation();
+        for (Object inner : (Iterable) obj) //TODO sort elements in case of a Set type to avoid leaking something. Or is that done by the Converter? No, cannot.
+            repr.put(elementHandler.serializeToRepresentation(inner));
+        return repr;
+    }
+}

--- a/src/main/java/de/upb/crypto/math/serialization/annotations/v2/internal/MapRepresentationHandler.java
+++ b/src/main/java/de/upb/crypto/math/serialization/annotations/v2/internal/MapRepresentationHandler.java
@@ -1,0 +1,102 @@
+package de.upb.crypto.math.serialization.annotations.v2.internal;
+
+import de.upb.crypto.math.serialization.MapRepresentation;
+import de.upb.crypto.math.serialization.Representation;
+import de.upb.crypto.math.serialization.annotations.v2.RepresentationRestorer;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.*;
+import java.util.function.Function;
+
+public class MapRepresentationHandler implements RepresentationHandler {
+    protected RepresentationHandler keyHandler, valueHandler;
+    protected Class mapType;
+    protected Type keyType;
+    protected Type valueType;
+
+    public MapRepresentationHandler(RepresentationHandler keyHandler, RepresentationHandler valueHandler, Type mapType) {
+        this.keyHandler = keyHandler;
+        this.valueHandler = valueHandler;
+        this.mapType = (Class) ((ParameterizedType) mapType).getRawType();
+        this.keyType = getKeyType(mapType);
+        this.valueType = getValueType(mapType);
+    }
+
+    public static Type getKeyType(Type mapType) {
+        Type[] typeArguments = ((ParameterizedType) mapType).getActualTypeArguments();
+        if (typeArguments.length != 2) {
+            throw new IllegalArgumentException("Can only handle maps with two generic type arguments");
+        }
+        return typeArguments[0];
+    }
+
+    public static Type getValueType(Type mapType) {
+        Type[] typeArguments = ((ParameterizedType) mapType).getActualTypeArguments();
+        if (typeArguments.length != 2) {
+            throw new IllegalArgumentException("Can only handle maps with two generic type arguments");
+        }
+        return typeArguments[1];
+    }
+
+    public static boolean canHandle(Type mapType) { //handles Map<anything>.
+        if (!(mapType instanceof ParameterizedType))
+            return false;
+
+        Type rawType = ((ParameterizedType) mapType).getRawType();
+
+        if (!(rawType instanceof Class))
+            return false;
+
+        if (!Map.class.isAssignableFrom((Class) rawType))
+            return false;
+
+        try { //Check if generic type argument is okay
+            getKeyType(mapType);
+            getValueType(mapType);
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+
+        //Check if the collection has a default constructor or is an interface.
+        try {
+            ((Class) rawType).getConstructor();
+        } catch (NoSuchMethodException e) {
+            return ((Class) rawType).isInterface() && ((Class) rawType).isAssignableFrom(LinkedHashMap.class);
+        }
+
+        return true;
+    }
+
+    @Override
+    public Object deserializeFromRepresentation(Representation repr, Function<String, RepresentationRestorer> getRegisteredRestorer) {
+        Map result = null;
+
+        //Try to call default constructor to create collection.
+        try {
+            result = (Map) mapType.getConstructor().newInstance();
+        } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) { //fall back to LinkedHashMap (e.g., if the field type is just Map<>)
+            if (mapType.isAssignableFrom(LinkedHashMap.class))
+                result = new LinkedHashMap();
+        }
+        if (result == null)
+            throw new RuntimeException("Cannot instantiate type "+ mapType.getName());
+
+        //Restore elements
+        for (Map.Entry<Representation, Representation> entry : repr.map())
+            result.put(keyHandler.deserializeFromRepresentation(entry.getKey(), getRegisteredRestorer),
+                    valueHandler.deserializeFromRepresentation(entry.getValue(), getRegisteredRestorer));
+
+        return result;
+    }
+
+    @Override
+    public Representation serializeToRepresentation(Object obj) {
+        if (!(obj instanceof Map))
+            throw new IllegalArgumentException("Cannot handle representation of "+obj.getClass().getName());
+        MapRepresentation repr = new MapRepresentation();
+        ((Map) obj).forEach((k, v) -> repr.put(keyHandler.serializeToRepresentation(k), valueHandler.serializeToRepresentation(v)));
+        return repr;
+    }
+}

--- a/src/main/java/de/upb/crypto/math/serialization/annotations/v2/internal/RepresentationHandler.java
+++ b/src/main/java/de/upb/crypto/math/serialization/annotations/v2/internal/RepresentationHandler.java
@@ -1,0 +1,14 @@
+package de.upb.crypto.math.serialization.annotations.v2.internal;
+
+import de.upb.crypto.math.serialization.Representation;
+import de.upb.crypto.math.serialization.annotations.v2.RepresentationRestorer;
+
+import java.util.function.Function;
+
+/**
+ * Interface internally used within ReprUtil
+ */
+public interface RepresentationHandler {
+    Object deserializeFromRepresentation(Representation repr, Function<String, RepresentationRestorer> getRegisteredRestorer);
+    Representation serializeToRepresentation(Object object);
+}

--- a/src/main/java/de/upb/crypto/math/serialization/annotations/v2/internal/StandaloneRepresentationHandler.java
+++ b/src/main/java/de/upb/crypto/math/serialization/annotations/v2/internal/StandaloneRepresentationHandler.java
@@ -20,7 +20,7 @@ public class StandaloneRepresentationHandler implements RepresentationHandler {
         this.type = type;
     }
 
-    static boolean canHandle(Type type) {
+    public static boolean canHandle(Type type) {
         if (!(type instanceof Class))
             return false;
         Class clazz = ((Class) type);

--- a/src/main/java/de/upb/crypto/math/serialization/annotations/v2/internal/StandaloneRepresentationHandler.java
+++ b/src/main/java/de/upb/crypto/math/serialization/annotations/v2/internal/StandaloneRepresentationHandler.java
@@ -1,0 +1,120 @@
+package de.upb.crypto.math.serialization.annotations.v2.internal;
+
+import de.upb.crypto.math.serialization.*;
+import de.upb.crypto.math.serialization.annotations.v2.RepresentationRestorer;
+
+import java.lang.reflect.Type;
+import java.math.BigInteger;
+import java.util.function.Function;
+
+/**
+ * Takes care of
+ * 1) StandaloneRepresentable
+ * 2) Some basic types (see static supportedTypes variable).
+ */
+public class StandaloneRepresentationHandler implements RepresentationHandler {
+    private static Class[] supportedTypes = new Class[] {StandaloneRepresentable.class, BigInteger.class, Integer.class, String.class, Boolean.class, byte[].class};
+    protected Class type;
+
+    public StandaloneRepresentationHandler(Class type) {
+        this.type = type;
+    }
+
+    static boolean canHandle(Type type) {
+        if (!(type instanceof Class))
+            return false;
+        Class clazz = ((Class) type);
+        for (Class supported : supportedTypes)
+            if (supported.isAssignableFrom(clazz))
+                return true;
+        return false;
+    }
+
+    @Override
+    public Object deserializeFromRepresentation(Representation repr, Function<String, RepresentationRestorer> getRegisteredRestorer) {
+        if (repr == null) {
+            return null;
+        }
+
+        try {
+            if (repr instanceof RepresentableRepresentation && type.isAssignableFrom(Class.forName(repr.repr().getRepresentedTypeName()) )) {
+                return repr.repr().recreateRepresentable();
+            }
+        } catch (ClassNotFoundException e) {
+            throw new IllegalArgumentException("Don't know how to recreate " + repr.repr().getRepresentedTypeName() + " - Class not found.", e);
+        }
+
+        if (type.isAssignableFrom(BigInteger.class) && repr instanceof BigIntegerRepresentation) {
+            return repr.bigInt().get();
+        }
+
+        if (type.isAssignableFrom(Integer.class) && repr instanceof IntegerRepresentation) {
+            return (int) ((IntegerRepresentation) repr).get();
+        }
+
+        if (type.isAssignableFrom(String.class) && repr instanceof StringRepresentation) {
+            return repr.str().get();
+        }
+
+        if (type.isAssignableFrom(Boolean.class) && repr instanceof BooleanRepresentation) {
+            return repr.bool().get();
+        }
+
+        if (type.isAssignableFrom(byte[].class) && repr instanceof ByteArrayRepresentation) {
+            return repr.bytes().get();
+        }
+
+        throw new IllegalArgumentException("Don't know how to recreate " + type.getName() + " from a "+repr.getClass().getName());
+    }
+
+    @Override
+    public Representation serializeToRepresentation(Object value) {
+        if (value == null) {
+            return null;
+        }
+
+        if (value instanceof Enum) {
+            Enum enumValue = (Enum) value;
+            return new RepresentableRepresentation(enumValue);
+        }
+
+        if (value instanceof StandaloneRepresentable) {
+            Representable repr = (Representable) value;
+            return new RepresentableRepresentation(repr);
+        }
+
+        if (value instanceof Representable) {
+            Representable repr = (Representable) value;
+            return repr.getRepresentation();
+        }
+
+        if (value instanceof BigInteger) {
+            BigInteger bigInt = (BigInteger) value;
+            return new BigIntegerRepresentation(bigInt);
+        }
+
+        if (value instanceof Integer) {
+            Integer integer = (Integer) value;
+            return new IntegerRepresentation(integer);
+        }
+
+        if (value instanceof String) {
+            String string = (String) value;
+            return new StringRepresentation(string);
+        }
+
+        if (value instanceof Boolean) {
+            Boolean bool = (Boolean) value;
+            return new BooleanRepresentation(bool);
+        }
+
+        if (value instanceof byte[]) {
+            byte[] bytes = (byte[]) value;
+            return new ByteArrayRepresentation(bytes);
+        }
+
+        throw new IllegalArgumentException("Object of type "+value.getClass().getName()+" is not StandaloneRepresentable" +
+                "(you may have to add an explicit 'handler' argument to the @Represented annotation)");
+    }
+
+}

--- a/src/main/java/de/upb/crypto/math/serialization/util/RepresentationToJavaObjectHelper.java
+++ b/src/main/java/de/upb/crypto/math/serialization/util/RepresentationToJavaObjectHelper.java
@@ -4,6 +4,7 @@ import de.upb.crypto.math.serialization.Representation;
 
 import java.lang.reflect.InvocationTargetException;
 
+@Deprecated //not required anymore. Will be removed in future releases.
 public class RepresentationToJavaObjectHelper {
     private static RepresentationToJavaObjectHelper instance = null;
 

--- a/src/main/java/de/upb/crypto/math/serialization/util/RepresentationUtil.java
+++ b/src/main/java/de/upb/crypto/math/serialization/util/RepresentationUtil.java
@@ -12,6 +12,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+@Deprecated //will be removed eventually. Superseded by ReprUtil and its annotation-based framwork.
 public class RepresentationUtil {
 
     /**


### PR DESCRIPTION
Added new framework annotation-based serialization.

- Got rid of `@RepresentedMapAndList` and such, now allowing arbitrary nesting. There is now a single annotation `@Represented` that takes a simple String description instructing how to deserialize.
- Allowing to use values that are not object fields for recreation, getting rid of weird workarounds that were previously done.
- Distributed code for handling magic-based serialization and deserialization (separation of concerns; for example, there is now a single class that handles representation of lists). 

Toy example containing two different groups, one of which (`group1`) is part of serialization, the other one is passed in the constructor:
```Java
@Represented(restorer = "group1 -> [group2]")
Map<GroupElement, List<GroupElement>> map;

@Represented
Group group1;

Constructor(Group g2, Representation repr) {
  new ReprUtil(this).register(g2, "group2").deserialize(repr);
}

Representation getRepresentation() {
  ReprUtil.serialize(this);
}
```

Changes are not API-breaking, but I've deprecated the old annotation API for eventual removal.

The `RepresentationRestorer` interface should be default-implemented by other interfaces that have `recreateFoo(Representation)` functions (e.g., `EncryptionScheme`).