### PR TITLE
Added support for parentheses in @Represented strings

### DIFF
--- a/src/main/java/de/upb/crypto/math/serialization/ByteArrayRepresentation.java
+++ b/src/main/java/de/upb/crypto/math/serialization/ByteArrayRepresentation.java
@@ -12,7 +12,7 @@ public class ByteArrayRepresentation extends Representation {
     }
 
     public ByteArrayRepresentation(byte[] data) {
-        this.data = data;
+        this.data = Arrays.copyOf(data, data.length);
     }
 
     public byte[] get() {

--- a/src/main/java/de/upb/crypto/math/serialization/StringRepresentation.java
+++ b/src/main/java/de/upb/crypto/math/serialization/StringRepresentation.java
@@ -4,13 +4,6 @@ public class StringRepresentation extends Representation {
     private static final long serialVersionUID = 4508386585732032537L;
     protected String s;
 
-    /**
-     * Instantiates an empty String representation.
-     */
-    public StringRepresentation() { //needed for Java serialization
-
-    }
-
     public StringRepresentation(String s) {
         this.s = s;
     }

--- a/src/main/java/de/upb/crypto/math/serialization/annotations/v2/ReprUtil.java
+++ b/src/main/java/de/upb/crypto/math/serialization/annotations/v2/ReprUtil.java
@@ -252,10 +252,12 @@ public class ReprUtil {
         if (StandaloneRepresentationHandler.canHandle(type))
             return new StandaloneRepresentationHandler((Class) type);
 
-        if (DependentRepresentationHandler.canHandle(type))
-            return new DependentRepresentationHandler(restorerString, type);
+        //Get rid of spaces and enclosing parentheses (if restorerString = "(FOO)")
+        String trimmedString = stripEnclosingParentheses(restorerString);
 
-        String trimmedString = restorerString.trim();
+        if (DependentRepresentationHandler.canHandle(type))
+            return new DependentRepresentationHandler(trimmedString, type);
+
         if (ListAndSetRepresentationHandler.canHandle(type) && trimmedString.startsWith("[") && trimmedString.endsWith("]")) {
             Type elementType = ListAndSetRepresentationHandler.getElementType(type);
             return new ListAndSetRepresentationHandler(getHandler(elementType, trimmedString.substring(1, trimmedString.length()-1)), type);
@@ -284,13 +286,15 @@ public class ReprUtil {
      * If none, returns -1.
      */
     private static int findMapArrow(String str) {
-        int depth = 0; //number of "[" read minus number of "]" read.
+        int depth = 0; //number of "[" or "(" read minus number of "]" or ")" read.
         for (int i=0;i<str.length();i++) {
             switch (str.charAt(i)) {
                 case '[':
+                case '(':
                     depth++;
                     break;
                 case ']':
+                case ')':
                     depth--;
                     break;
                 case '-':
@@ -300,5 +304,31 @@ public class ReprUtil {
             }
         }
         return -1;
+    }
+
+    /**
+     * If the expression is of the form "( ... )" (where the two parentheses are matching), removes those parentheses.
+     * For example, "(x)" would become "x", but "(x) -> (y)" would not be modified.
+     */
+    private static String stripEnclosingParentheses(String str) {
+        str = str.trim();
+        if (!str.startsWith("(") || !str.endsWith(")"))
+            return str;
+
+        int depth = 1; //number of  "(" read minus number of ")" read.
+        for (int i=1;i<str.length()-1;i++) { //loop indices exclude first and last parentheses.
+            switch (str.charAt(i)) {
+                case '(':
+                    depth++;
+                    break;
+                case ')':
+                    depth--;
+                    break;
+            }
+            if (depth == 0) //found parenthesis matching the str[0] one (which is not the str[len-1] one)
+                return str;
+        }
+
+        return stripEnclosingParentheses(str.substring(1, str.length()-1)); //recursively call to remove more parentheses if necessary
     }
 }

--- a/src/main/java/de/upb/crypto/math/serialization/annotations/v2/Represented.java
+++ b/src/main/java/de/upb/crypto/math/serialization/annotations/v2/Represented.java
@@ -23,6 +23,7 @@ public @interface Represented {
      * For a map, whose keys are handled by G1 and whose values by G2, write "G1 -> G2".
      *
      * These can be combined, e.g., "G1 -> [[G2]]" for a map whose keys are handled by G1 and whose values are lists of lists of G2.
+     * You can use parentheses to ensure precedence, e.g., "(G1 -> G2) -> G3" is a map whose keys are maps from G1 to G2.
      *
      * If the type is simple (i.e. StandaloneRepresentable, BigInteger, Integer, String, Boolean, or byte[]), this value is ignored.
      * This is again true for nested expressions, e.g., "FOO -> G2" works for a Map from String to GroupElement, as the String "FOO" is simply ignored.

--- a/src/test/java/de/upb/crypto/math/serialization/annotations/test/ReprUtilTest.java
+++ b/src/test/java/de/upb/crypto/math/serialization/annotations/test/ReprUtilTest.java
@@ -1,0 +1,41 @@
+package de.upb.crypto.math.serialization.annotations.test;
+
+
+import de.upb.crypto.math.interfaces.structures.Ring;
+import de.upb.crypto.math.interfaces.structures.RingElement;
+import de.upb.crypto.math.serialization.Representation;
+import de.upb.crypto.math.serialization.annotations.v2.ReprUtil;
+import de.upb.crypto.math.serialization.annotations.v2.Represented;
+import de.upb.crypto.math.structures.zn.Zn;
+import org.junit.Test;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class ReprUtilTest {
+    @Represented(restorer = "(Str -> R) -> [Str]")
+    HashMap<Map<String, RingElement>, List<String>> nestedMap;
+
+    @Test
+    public void testNestedMap() {
+        Ring ring  = new Zn(BigInteger.TEN);
+
+        HashMap<Map<String, RingElement>, List<String>> nestedMapOriginal = new HashMap<>();
+        Map<String, RingElement> inner = new HashMap<>();
+        inner.put("testInner", ring.getUniformlyRandomElement());
+        nestedMap = nestedMapOriginal;
+
+        nestedMapOriginal.put(inner, Arrays.asList("testOuter"));
+
+        Representation repr = ReprUtil.serialize(this);
+        nestedMap = null;
+        new ReprUtil(this).register(ring, "R").deserialize(repr);
+
+        assertEquals(nestedMapOriginal, nestedMap);
+    }
+}


### PR DESCRIPTION
Added support for parentheses in `@Represented` description strings.
This allows for descriptions like `"(G1 -> G2) -> G3"`, which is a map whose keys are maps from G1 to G2.