### PR TITLE
Remove log4j dependency and fix simplerandomgenerator package declaration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,6 @@ dependencies {
 
     // This dependency is used internally, and not exposed to consumers on their own compile classpath.
     implementation group: 'com.googlecode.json-simple', name: 'json-simple', version:'1.1'
-    implementation group: 'log4j', name: 'log4j', version:'1.2.17'
     implementation group: 'org.reflections', name: 'reflections', version:'0.9.10'
     implementation group: 'javax.xml.bind', name: 'jaxb-api', version:'2.1'
 

--- a/src/main/java/de/upb/crypto/math/random/SimpleRandomGenerator.java
+++ b/src/main/java/de/upb/crypto/math/random/SimpleRandomGenerator.java
@@ -1,4 +1,4 @@
-package de.upb.crypto.math.random.SimpleRandomGenerator;
+package de.upb.crypto.math.random;
 
 import de.upb.crypto.math.random.interfaces.RandomGenerator;
 

--- a/src/main/java/de/upb/crypto/math/random/interfaces/RandomGeneratorSupplier.java
+++ b/src/main/java/de/upb/crypto/math/random/interfaces/RandomGeneratorSupplier.java
@@ -1,6 +1,6 @@
 package de.upb.crypto.math.random.interfaces;
 
-import de.upb.crypto.math.random.SimpleRandomGenerator.SimpleRandomGenerator;
+import de.upb.crypto.math.random.SimpleRandomGenerator;
 
 /**
  * A static way to obtain random generators.

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,7 +1,0 @@
-# Root logger option
-log4j.rootLogger=TRACE, stdout
-# Redirect log messages to console
-log4j.appender.stdout=org.apache.log4j.ConsoleAppender
-log4j.appender.stdout.Target=System.out
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n


### PR DESCRIPTION
Closes #15. Log4j was not even used anywhere, so this is a very tiny pull request.