### PR TITLE
Fix CountingHomomorphism

### DIFF
--- a/src/main/java/de/upb/crypto/math/pairings/debug/count/CountingHomomorphism.java
+++ b/src/main/java/de/upb/crypto/math/pairings/debug/count/CountingHomomorphism.java
@@ -34,8 +34,8 @@ public class CountingHomomorphism implements GroupHomomorphism {
     public GroupElement apply(GroupElement groupElement) {
         return new CountingGroupElement(
                 new CountingGroup(totalHom.getTargetGroup(), expMultiExpHom.getTargetGroup()),
-                totalHom.apply(groupElement),
-                expMultiExpHom.apply(groupElement)
+                totalHom.apply(((CountingGroupElement) groupElement).elemTotal),
+                expMultiExpHom.apply(((CountingGroupElement) groupElement).elemExpMultiExp)
         );
     }
 

--- a/src/test/java/de/upb/crypto/math/hashfunctions/test/HashFunctionTest.java
+++ b/src/test/java/de/upb/crypto/math/hashfunctions/test/HashFunctionTest.java
@@ -1,4 +1,4 @@
-package de.upb.crypto.math.hahsfunctions.test;
+package de.upb.crypto.math.hashfunctions.test;
 
 
 import de.upb.crypto.math.hash.impl.SHA256HashFunction;

--- a/src/test/java/de/upb/crypto/math/structures/test/CountingTest.java
+++ b/src/test/java/de/upb/crypto/math/structures/test/CountingTest.java
@@ -11,8 +11,7 @@ import org.junit.Test;
 
 import java.math.BigInteger;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class CountingTest {
 
@@ -161,5 +160,17 @@ public class CountingTest {
         assertArrayEquals(new Integer[] {}, groupG1.getMultiExpTermNumbers().toArray(new Integer[] {}));
 
         assertEquals(0, bilGroup.getNumPairings());
+    }
+
+    @Test
+    public void testCountingHomomorphism() {
+        CountingGroup groupG1 = (CountingGroup) bilGroup.getG1();
+        CountingGroup groupG2 = (CountingGroup) bilGroup.getG2();
+
+        GroupElement elemG1;
+        GroupElement elemG2 = groupG2.getUniformlyRandomNonNeutral();
+
+        elemG1 = bilGroup.getHomomorphismG2toG1().apply(elemG2);
+        assertEquals(elemG1.getStructure(), groupG1);
     }
 }


### PR DESCRIPTION
Fixes an issue with CountingHomomorphism where the homomorphism operation of the contained lazy homorphism instances is applied to the `CountingGroupElement` and not the nested `LazyGroupElement` instances.