### PR TITLE
Random changes made during protocols development

### DIFF
--- a/src/main/java/de/upb/crypto/math/expressions/Expression.java
+++ b/src/main/java/de/upb/crypto/math/expressions/Expression.java
@@ -6,6 +6,7 @@ import de.upb.crypto.math.expressions.exponent.BasicNamedExponentVariableExpr;
 import de.upb.crypto.math.expressions.exponent.ExponentExpr;
 import de.upb.crypto.math.expressions.group.BasicNamedGroupVariableExpr;
 import de.upb.crypto.math.expressions.group.GroupElementExpression;
+import de.upb.crypto.math.expressions.group.GroupOpExpr;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -30,8 +31,9 @@ public interface Expression {
 
         throw new IllegalArgumentException("Don't know how to handle "+substitution.getClass());
     }
+
     /**
-     * Substitute a specific variable with the given expression.
+     * Substitutes a specific variable with the given expression.
      *
      * @param variable the variable to replace
      * @param substitution the expression to substitute
@@ -93,7 +95,7 @@ public interface Expression {
      *         forEachChild(Expression::treeWalk)
      *     }
      * </pre>
-     * By contract, implementing objects should at least regard dependent variables as child VariableExpressions.
+     * By contract, implementing objects should at least regard dependent variables as child variable expressions.
      */
     default void treeWalk(Consumer<Expression> visitor) {
         visitor.accept(this);

--- a/src/main/java/de/upb/crypto/math/expressions/Substitution.java
+++ b/src/main/java/de/upb/crypto/math/expressions/Substitution.java
@@ -2,17 +2,21 @@ package de.upb.crypto.math.expressions;
 
 @FunctionalInterface
 public interface Substitution {
+
     /**
      * Indicates what the given expr shall be replaced with.
      *
      * @param expr the candidate expression to replace
-     * @return the new Expression to replace expr with, or null to indicate no substitution shall be applied
+     * @return the new expression to replace expr with, or null to indicate no substitution shall be applied
      */
     Expression getSubstitution(VariableExpression expr);
 
     /**
-     * Returns a substitution that gets its entries from this substitution or the other.
-     * The resulting Substitution will fail with Exception if both this Substitution and the other return non-null on the same input.
+     * Returns a substitution that gets its entries from this substitution or the given one.
+     * The resulting substitution will fail with {@code IllegalArgumentException} if both this substitution
+     * and the given one return non-null on the same input, i.e. they are not disjoint.
+     *
+     * @param other the substitution to execute the disjoint join with
      */
     default Substitution joinDisjoint(Substitution other) {
         return expr -> {
@@ -27,7 +31,9 @@ public interface Substitution {
     }
 
     /**
-     * Returns a substitution that gets falls back to "other" substitution if this substitution doesn't have a value.
+     * Returns a substitution that falls back to the given substitution if this substitution doesn't have a value.
+     *
+     * @param other the substitution to fall back to
      */
     default Substitution join(Substitution other) {
         return expr -> {
@@ -38,6 +44,12 @@ public interface Substitution {
         };
     }
 
+    /**
+     * Returns a substitution that falls back to the given substitutions if this substitution doesn't have a value.
+     * The fallback substitutions are considered in the given order.
+     *
+     * @param subs the substitutions to fall back to
+     */
     static Substitution join(Substitution... subs) {
         return expr -> {
             for (Substitution sub : subs) {
@@ -49,6 +61,13 @@ public interface Substitution {
         };
     }
 
+    /**
+     * Returns a substitution that falls back to the given substitutions if this substitution doesn't have a value
+     * and additionally ignores any {@code NullPointerException}s that occur.
+     * The fallback substitutions are considered in the given order.
+     *
+     * @param subs the substitutions to fall back to
+     */
     static Substitution joinAndIgnoreNullpointers(Substitution... subs) {
         return expr -> {
             for (Substitution sub : subs) {
@@ -62,6 +81,16 @@ public interface Substitution {
         };
     }
 
+
+    /**
+     * Returns a new substitution that is constructed by executing a disjoint join on this substitution and the
+     * given ones. Disjoint means that the resulting substitution throws a {@code IllegalArgumentException} if
+     * more than one of the base substitutions has a value for a given expression.
+     *
+     * @see #joinDisjoint(Substitution)
+     *
+     * @param subs the substitutions to join with
+     */
     static Substitution joinDisjoint(Substitution... subs) {
         return expr -> {
             int numResults = 0;

--- a/src/main/java/de/upb/crypto/math/expressions/Substitution.java
+++ b/src/main/java/de/upb/crypto/math/expressions/Substitution.java
@@ -1,0 +1,80 @@
+package de.upb.crypto.math.expressions;
+
+@FunctionalInterface
+public interface Substitution {
+    /**
+     * Indicates what the given expr shall be replaced with.
+     *
+     * @param expr the candidate expression to replace
+     * @return the new Expression to replace expr with, or null to indicate no substitution shall be applied
+     */
+    Expression getSubstitution(VariableExpression expr);
+
+    /**
+     * Returns a substitution that gets its entries from this substitution or the other.
+     * The resulting Substitution will fail with Exception if both this Substitution and the other return non-null on the same input.
+     */
+    default Substitution joinDisjoint(Substitution other) {
+        return expr -> {
+            Expression ours = this.getSubstitution(expr);
+            Expression theirs = other.getSubstitution(expr);
+
+            if (ours != null && theirs != null)
+                throw new IllegalArgumentException("Substitutions are not disjoint");
+
+            return theirs == null ? ours : theirs;
+        };
+    }
+
+    /**
+     * Returns a substitution that gets falls back to "other" substitution if this substitution doesn't have a value.
+     */
+    default Substitution join(Substitution other) {
+        return expr -> {
+            Expression ours = this.getSubstitution(expr);
+            if (ours == null)
+                return other.getSubstitution(expr);
+            return ours;
+        };
+    }
+
+    static Substitution join(Substitution... subs) {
+        return expr -> {
+            for (Substitution sub : subs) {
+                Expression result = sub.getSubstitution(expr);
+                if (result != null)
+                    return result;
+            }
+            return null;
+        };
+    }
+
+    static Substitution joinAndIgnoreNullpointers(Substitution... subs) {
+        return expr -> {
+            for (Substitution sub : subs) {
+                try {
+                    Expression result = sub.getSubstitution(expr);
+                    if (result != null)
+                        return result;
+                } catch (NullPointerException ignored) {}
+            }
+            return null;
+        };
+    }
+
+    static Substitution joinDisjoint(Substitution... subs) {
+        return expr -> {
+            int numResults = 0;
+            Expression result = null;
+            for (Substitution sub : subs) {
+                result = sub.getSubstitution(expr);
+                numResults++;
+            }
+
+            if (numResults > 1)
+                throw new IllegalArgumentException("Substitutions are not disjoint");
+
+            return result;
+        };
+    }
+}

--- a/src/main/java/de/upb/crypto/math/expressions/ValueBundle.java
+++ b/src/main/java/de/upb/crypto/math/expressions/ValueBundle.java
@@ -21,23 +21,24 @@ import java.util.HashMap;
  * These values can be used to substitute variables with the same name in some {@link Expression}.
  */
 public class ValueBundle implements Substitution{
+
     /**
-     * Maps variable names to substitute {@code GroupElement}'s.
+     * Maps variable expressions to substitute {@code GroupElement}s.
      */
     protected HashMap<VariableExpression, GroupElement> groupElems;
 
     /**
-     * Maps variable names to substitute {@code BigInteger}'s.
+     * Maps variable expressions to substitute {@code BigInteger}s.
      */
     protected HashMap<VariableExpression, BigInteger> ints;
 
     /**
-     * Maps variable names to substitute {@code RingElement}'s.
+     * Maps variable expressions to substitute {@code RingElement}s.
      */
     protected HashMap<VariableExpression, RingElement> ringElems;
 
     /**
-     * Maps variable names to substitute {@code Boolean}'s.
+     * Maps variable expressions to substitute {@code Boolean}s.
      */
     protected HashMap<VariableExpression, Boolean> bools;
     //protected HashMap<VariableExpression, ValueList> lists = new HashMap<>(); //Not yet implemented
@@ -62,7 +63,7 @@ public class ValueBundle implements Substitution{
     }
 
     /**
-     * Creates copy of this {@code ValueBundle}.
+     * Creates a copy of this {@code ValueBundle}.
      * <p>
      * The maps used to store the algebraic elements are recreated, the elements themselves are not cloned.
      */
@@ -70,24 +71,63 @@ public class ValueBundle implements Substitution{
         return new ValueBundle(this);
     }
 
+    /**
+     * Returns the {@code GroupElement} corresponding to the given variable expression.
+     *
+     * @param key the variable expression to retrieve the element for
+     * @return the corresponding group element
+     */
     public GroupElement getGroupElement(VariableExpression key) {
         return groupElems.get(key);
     }
 
+    /**
+     * Returns the {@code RingElement} corresponding to the given variable expression.
+     *
+     * @param key the variable expression to retrieve the element for
+     * @return the corresponding ring element
+     */
     public RingElement getRingElement(VariableExpression key) {
         return ringElems.get(key);
     }
 
+    /**
+     * Returns the {@code ZnElement} corresponding to the given variable expression.
+     *
+     * @param key the variable expression to retrieve the element for
+     * @return the corresponding Zn element
+     */
     public Zn.ZnElement getZnElement(VariableExpression key) {
         return (Zn.ZnElement) ringElems.get(key);
     }
 
+    /**
+     * Returns the {@code ZpElement} corresponding to the given variable expression.
+     *
+     * @param key the variable expression to retrieve the element for
+     * @return the corresponding Zp element
+     */
     public Zp.ZpElement getZpElement(VariableExpression key) {
         return (Zp.ZpElement) ringElems.get(key);
     }
 
+    /**
+     * Returns the {@code Boolean} corresponding to the given variable expression.
+     *
+     * @param key the variable expression to retrieve the Boolean for
+     * @return the corresponding Boolean
+     */
     public Boolean getBoolean(VariableExpression key) { return bools.get(key); }
 
+    /**
+     * Retrieves the {@code BigInteger} corresponding to the given variable expression.
+     * <p>
+     * If the desired integer cannot be found, the method looks for an integer-like ring element
+     * with the given key instead.
+     *
+     * @param key the variable expression to retrieve the integer for
+     * @return the corresponding integer
+     */
     public BigInteger getInteger(VariableExpression key) {
         if (ints.containsKey(key))
             return ints.get(key);

--- a/src/main/java/de/upb/crypto/math/expressions/VariableExpression.java
+++ b/src/main/java/de/upb/crypto/math/expressions/VariableExpression.java
@@ -1,11 +1,8 @@
 package de.upb.crypto.math.expressions;
 
 /**
- * A {@code VariableExpression} is an {@link Expression} that represents a variable with a specific name.
+ * A {@code VariableExpression} is an {@link Expression} that represents a variable.
  */
 public interface VariableExpression extends Expression {
-    /**
-     * Retrieves the name of this variable.
-     */
-    String getName();
+
 }

--- a/src/main/java/de/upb/crypto/math/expressions/bool/BasicNamedBoolVariableExpr.java
+++ b/src/main/java/de/upb/crypto/math/expressions/bool/BasicNamedBoolVariableExpr.java
@@ -1,0 +1,54 @@
+package de.upb.crypto.math.expressions.bool;
+
+import de.upb.crypto.math.expressions.EvaluationException;
+import de.upb.crypto.math.expressions.Expression;
+import de.upb.crypto.math.expressions.Substitution;
+import de.upb.crypto.math.interfaces.hash.ByteAccumulator;
+import de.upb.crypto.math.interfaces.hash.UniqueByteRepresentable;
+import de.upb.crypto.math.serialization.Representable;
+import de.upb.crypto.math.serialization.Representation;
+import de.upb.crypto.math.serialization.StringRepresentation;
+
+import javax.annotation.Nonnull;
+import java.util.Objects;
+import java.util.function.Consumer;
+
+public final class BasicNamedBoolVariableExpr implements BoolVariableExpr, Representable, UniqueByteRepresentable {
+    protected final String name;
+
+    public BasicNamedBoolVariableExpr(@Nonnull String name) {
+        this.name = name;
+    }
+
+    public BasicNamedBoolVariableExpr(Representation repr) {
+        this(repr.str().get());
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof BasicNamedBoolVariableExpr)) return false;
+        BasicNamedBoolVariableExpr that = (BasicNamedBoolVariableExpr) o;
+        return name.equals(that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name);
+    }
+
+    @Override
+    public Representation getRepresentation() {
+        return new StringRepresentation(name);
+    }
+
+    @Override
+    public ByteAccumulator updateAccumulator(ByteAccumulator accumulator) {
+        accumulator.append(name);
+        return accumulator;
+    }
+}

--- a/src/main/java/de/upb/crypto/math/expressions/bool/BasicNamedBoolVariableExpr.java
+++ b/src/main/java/de/upb/crypto/math/expressions/bool/BasicNamedBoolVariableExpr.java
@@ -1,8 +1,5 @@
 package de.upb.crypto.math.expressions.bool;
 
-import de.upb.crypto.math.expressions.EvaluationException;
-import de.upb.crypto.math.expressions.Expression;
-import de.upb.crypto.math.expressions.Substitution;
 import de.upb.crypto.math.interfaces.hash.ByteAccumulator;
 import de.upb.crypto.math.interfaces.hash.UniqueByteRepresentable;
 import de.upb.crypto.math.serialization.Representable;
@@ -11,9 +8,15 @@ import de.upb.crypto.math.serialization.StringRepresentation;
 
 import javax.annotation.Nonnull;
 import java.util.Objects;
-import java.util.function.Consumer;
 
+/**
+ * A {@link BoolVariableExpr} with a specific name.
+ */
 public final class BasicNamedBoolVariableExpr implements BoolVariableExpr, Representable, UniqueByteRepresentable {
+
+    /**
+     * The name of this variable expression.
+     */
     protected final String name;
 
     public BasicNamedBoolVariableExpr(@Nonnull String name) {

--- a/src/main/java/de/upb/crypto/math/expressions/bool/BoolAndExpr.java
+++ b/src/main/java/de/upb/crypto/math/expressions/bool/BoolAndExpr.java
@@ -1,10 +1,9 @@
 package de.upb.crypto.math.expressions.bool;
 
 import de.upb.crypto.math.expressions.Expression;
-import de.upb.crypto.math.expressions.VariableExpression;
+import de.upb.crypto.math.expressions.Substitution;
 
 import java.util.function.Consumer;
-import java.util.function.Function;
 
 /**
  * A {@link BooleanExpression} representing the Boolean AND of two {@code BooleanExpression} instances.
@@ -26,12 +25,12 @@ public class BoolAndExpr implements BooleanExpression {
     }
 
     @Override
-    public BooleanExpression substitute(Function<VariableExpression, ? extends Expression> substitutions) {
+    public BooleanExpression substitute(Substitution substitutions) {
         return lhs.substitute(substitutions).and(rhs.substitute(substitutions));
     }
 
     @Override
-    public Boolean evaluate(Function<VariableExpression, ? extends Expression> substitutions) {
+    public Boolean evaluate(Substitution substitutions) {
         return lhs.evaluate(substitutions) && rhs.evaluate(substitutions);
     }
 

--- a/src/main/java/de/upb/crypto/math/expressions/bool/BoolConstantExpr.java
+++ b/src/main/java/de/upb/crypto/math/expressions/bool/BoolConstantExpr.java
@@ -1,10 +1,9 @@
 package de.upb.crypto.math.expressions.bool;
 
 import de.upb.crypto.math.expressions.Expression;
-import de.upb.crypto.math.expressions.VariableExpression;
+import de.upb.crypto.math.expressions.Substitution;
 
 import java.util.function.Consumer;
-import java.util.function.Function;
 
 /**
  * A {@link BooleanExpression} representing a constant Boolean value.
@@ -20,12 +19,12 @@ public class BoolConstantExpr implements BooleanExpression {
     }
 
     @Override
-    public BooleanExpression substitute(Function<VariableExpression, ? extends Expression> substitutions) {
+    public BooleanExpression substitute(Substitution substitutions) {
         return this;
     }
 
     @Override
-    public Boolean evaluate(Function<VariableExpression, ? extends Expression> substitutions) {
+    public Boolean evaluate(Substitution substitutions) {
         return value;
     }
 

--- a/src/main/java/de/upb/crypto/math/expressions/bool/BoolEmptyExpr.java
+++ b/src/main/java/de/upb/crypto/math/expressions/bool/BoolEmptyExpr.java
@@ -1,10 +1,9 @@
 package de.upb.crypto.math.expressions.bool;
 
 import de.upb.crypto.math.expressions.Expression;
-import de.upb.crypto.math.expressions.VariableExpression;
+import de.upb.crypto.math.expressions.Substitution;
 
 import java.util.function.Consumer;
-import java.util.function.Function;
 
 /**
  * A {@link BooleanExpression} representing an empty expression useful for instantiating a new Boolean expression.
@@ -17,7 +16,7 @@ import java.util.function.Function;
 public class BoolEmptyExpr implements BooleanExpression {
 
     @Override
-    public BooleanExpression substitute(Function<VariableExpression, ? extends Expression> substitutions) {
+    public BooleanExpression substitute(Substitution substitutions) {
         return this;
     }
 
@@ -27,7 +26,7 @@ public class BoolEmptyExpr implements BooleanExpression {
     }
 
     @Override
-    public Boolean evaluate(Function<VariableExpression, ? extends Expression> substitutions) {
+    public Boolean evaluate(Substitution substitutions) {
         return evaluate();
     }
 

--- a/src/main/java/de/upb/crypto/math/expressions/bool/BoolNotExpr.java
+++ b/src/main/java/de/upb/crypto/math/expressions/bool/BoolNotExpr.java
@@ -1,10 +1,9 @@
 package de.upb.crypto.math.expressions.bool;
 
 import de.upb.crypto.math.expressions.Expression;
-import de.upb.crypto.math.expressions.VariableExpression;
+import de.upb.crypto.math.expressions.Substitution;
 
 import java.util.function.Consumer;
-import java.util.function.Function;
 
 /**
  * A {@link BooleanExpression} representing the Boolean NOT of a Boolean expression.
@@ -27,12 +26,12 @@ public class BoolNotExpr implements BooleanExpression {
     }
 
     @Override
-    public BooleanExpression substitute(Function<VariableExpression, ? extends Expression> substitutions) {
+    public BooleanExpression substitute(Substitution substitutions) {
         return child.substitute(substitutions).not();
     }
 
     @Override
-    public Boolean evaluate(Function<VariableExpression, ? extends Expression> substitutions) {
+    public Boolean evaluate(Substitution substitutions) {
         return !child.evaluate(substitutions);
     }
 

--- a/src/main/java/de/upb/crypto/math/expressions/bool/BoolOrExpr.java
+++ b/src/main/java/de/upb/crypto/math/expressions/bool/BoolOrExpr.java
@@ -1,10 +1,9 @@
 package de.upb.crypto.math.expressions.bool;
 
 import de.upb.crypto.math.expressions.Expression;
-import de.upb.crypto.math.expressions.VariableExpression;
+import de.upb.crypto.math.expressions.Substitution;
 
 import java.util.function.Consumer;
-import java.util.function.Function;
 
 /**
  * A {@link BooleanExpression} representing the Boolean OR of two {@code BooleanExpression} instances.
@@ -40,12 +39,12 @@ public class BoolOrExpr implements BooleanExpression {
     }
 
     @Override
-    public BooleanExpression substitute(Function<VariableExpression, ? extends Expression> substitutions) {
+    public BooleanExpression substitute(Substitution substitutions) {
         return lhs.substitute(substitutions).or(rhs.substitute(substitutions));
     }
 
     @Override
-    public Boolean evaluate(Function<VariableExpression, ? extends Expression> substitutions) {
+    public Boolean evaluate(Substitution substitutions) {
         return lhs.evaluate(substitutions) || rhs.evaluate(substitutions);
     }
 

--- a/src/main/java/de/upb/crypto/math/expressions/bool/BoolVariableExpr.java
+++ b/src/main/java/de/upb/crypto/math/expressions/bool/BoolVariableExpr.java
@@ -2,53 +2,37 @@ package de.upb.crypto.math.expressions.bool;
 
 import de.upb.crypto.math.expressions.EvaluationException;
 import de.upb.crypto.math.expressions.Expression;
+import de.upb.crypto.math.expressions.Substitution;
 import de.upb.crypto.math.expressions.VariableExpression;
 
 import java.util.function.Consumer;
-import java.util.function.Function;
-
 /**
  * A {@link BooleanExpression} representing a variable, a Boolean whose actual Boolean value is not currently known.
  */
-public class BoolVariableExpr implements VariableExpression, BooleanExpression {
-    /**
-     * The name of this variable.
-     */
-    protected final String name;
-
-    public BoolVariableExpr(String name) {
-        this.name = name;
-    }
-
+public interface BoolVariableExpr extends VariableExpression, BooleanExpression {
     @Override
-    public String getName() {
-        return name;
-    }
-
-    @Override
-    public BooleanExpression substitute(Function<VariableExpression, ? extends Expression> substitutions) {
-        Expression replacement = substitutions.apply(this);
-        if (replacement != null)
-            return (BooleanExpression) replacement;
-        return this;
-    }
-
-    @Override
-    public Boolean evaluate() {
+    default Boolean evaluate() {
         throw new EvaluationException(this, "Variable has no value");
     }
 
     @Override
-    public Boolean evaluate(Function<VariableExpression, ? extends Expression> substitutions) {
-        BooleanExpression substitution = (BooleanExpression) substitutions.apply(this);
+    default Boolean evaluate(Substitution substitutions) {
+        BooleanExpression substitution = (BooleanExpression) substitutions.getSubstitution(this);
         if (substitution == null)
             throw new EvaluationException(this, "Variable cannot be evaluated");
         return substitution.evaluate();
     }
 
     @Override
-    public void forEachChild(Consumer<Expression> action) {
+    default void forEachChild(Consumer<Expression> action) {
         //Nothing to do
     }
 
+    @Override
+    default BooleanExpression substitute(Substitution substitutions) {
+        Expression replacement = substitutions.getSubstitution(this);
+        if (replacement != null)
+            return (BooleanExpression) replacement;
+        return this;
+    }
 }

--- a/src/main/java/de/upb/crypto/math/expressions/bool/BooleanExpression.java
+++ b/src/main/java/de/upb/crypto/math/expressions/bool/BooleanExpression.java
@@ -1,25 +1,23 @@
 package de.upb.crypto.math.expressions.bool;
 
 import de.upb.crypto.math.expressions.Expression;
-import de.upb.crypto.math.expressions.ValueBundle;
+import de.upb.crypto.math.expressions.Substitution;
 import de.upb.crypto.math.expressions.VariableExpression;
-
-import java.util.function.Function;
 
 /**
  * An {@link Expression} that evaluates to a {@code Boolean}.
  */
 public interface BooleanExpression extends Expression {
     @Override
-    default BooleanExpression substitute(ValueBundle values) {
-        return (BooleanExpression) Expression.super.substitute(values);
-    }
-
-    @Override
-    BooleanExpression substitute(Function<VariableExpression, ? extends Expression> substitutions);
+    BooleanExpression substitute(Substitution substitutions);
 
     @Override
     default BooleanExpression substitute(String variable, Expression substitution) {
+        return (BooleanExpression) Expression.super.substitute(variable, substitution);
+    }
+
+    @Override
+    default BooleanExpression substitute(VariableExpression variable, Expression substitution) {
         return (BooleanExpression) Expression.super.substitute(variable, substitution);
     }
 
@@ -29,7 +27,7 @@ public interface BooleanExpression extends Expression {
     }
 
     @Override
-    Boolean evaluate(Function<VariableExpression, ? extends Expression> substitutions);
+    Boolean evaluate(Substitution substitutions);
 
     /**
      * Applies a Boolean AND to this and the given Boolean expression.

--- a/src/main/java/de/upb/crypto/math/expressions/bool/ExponentEqualityExpr.java
+++ b/src/main/java/de/upb/crypto/math/expressions/bool/ExponentEqualityExpr.java
@@ -1,6 +1,7 @@
 package de.upb.crypto.math.expressions.bool;
 
 import de.upb.crypto.math.expressions.Expression;
+import de.upb.crypto.math.expressions.Substitution;
 import de.upb.crypto.math.expressions.VariableExpression;
 import de.upb.crypto.math.expressions.exponent.ExponentExpr;
 
@@ -28,12 +29,12 @@ public class ExponentEqualityExpr implements BooleanExpression {
     }
 
     @Override
-    public BooleanExpression substitute(Function<VariableExpression, ? extends Expression> substitutions) {
+    public BooleanExpression substitute(Substitution substitutions) {
         return lhs.substitute(substitutions).isEqualTo(rhs.substitute(substitutions));
     }
 
     @Override
-    public Boolean evaluate(Function<VariableExpression, ? extends Expression> substitutions) {
+    public Boolean evaluate(Substitution substitutions) {
         return lhs.sub(rhs).evaluate().equals(BigInteger.ZERO);
     }
 

--- a/src/main/java/de/upb/crypto/math/expressions/bool/GroupEqualityExpr.java
+++ b/src/main/java/de/upb/crypto/math/expressions/bool/GroupEqualityExpr.java
@@ -1,12 +1,11 @@
 package de.upb.crypto.math.expressions.bool;
 
 import de.upb.crypto.math.expressions.Expression;
-import de.upb.crypto.math.expressions.VariableExpression;
+import de.upb.crypto.math.expressions.Substitution;
 import de.upb.crypto.math.expressions.group.GroupElementExpression;
 import de.upb.crypto.math.interfaces.structures.Group;
 
 import java.util.function.Consumer;
-import java.util.function.Function;
 
 /**
  * A {@link BooleanExpression} representing the Boolean equality "=" of two {@link GroupElementExpression} instances.
@@ -46,12 +45,12 @@ public class GroupEqualityExpr implements BooleanExpression {
     }
 
     @Override
-    public BooleanExpression substitute(Function<VariableExpression, ? extends Expression> substitutions) {
+    public BooleanExpression substitute(Substitution substitutions) {
         return lhs.substitute(substitutions).isEqualTo(rhs.substitute(substitutions));
     }
 
     @Override
-    public Boolean evaluate(Function<VariableExpression, ? extends Expression> substitutions) {
+    public Boolean evaluate(Substitution substitutions) {
         return lhs.evaluate(substitutions).equals(rhs.evaluate(substitutions));
     }
 

--- a/src/main/java/de/upb/crypto/math/expressions/exponent/BasicNamedExponentVariableExpr.java
+++ b/src/main/java/de/upb/crypto/math/expressions/exponent/BasicNamedExponentVariableExpr.java
@@ -8,7 +8,14 @@ import de.upb.crypto.math.serialization.StringRepresentation;
 
 import java.util.Objects;
 
+/**
+ * A {@link ExponentVariableExpr} with a specific name.
+ */
 public final class BasicNamedExponentVariableExpr implements ExponentVariableExpr, Representable, UniqueByteRepresentable {
+
+    /**
+     * The name of this variable expression.
+     */
     protected final String name;
 
     public BasicNamedExponentVariableExpr(String name) {

--- a/src/main/java/de/upb/crypto/math/expressions/exponent/BasicNamedExponentVariableExpr.java
+++ b/src/main/java/de/upb/crypto/math/expressions/exponent/BasicNamedExponentVariableExpr.java
@@ -1,0 +1,49 @@
+package de.upb.crypto.math.expressions.exponent;
+
+import de.upb.crypto.math.interfaces.hash.ByteAccumulator;
+import de.upb.crypto.math.interfaces.hash.UniqueByteRepresentable;
+import de.upb.crypto.math.serialization.Representable;
+import de.upb.crypto.math.serialization.Representation;
+import de.upb.crypto.math.serialization.StringRepresentation;
+
+import java.util.Objects;
+
+public final class BasicNamedExponentVariableExpr implements ExponentVariableExpr, Representable, UniqueByteRepresentable {
+    protected final String name;
+
+    public BasicNamedExponentVariableExpr(String name) {
+        this.name = name;
+    }
+
+    public BasicNamedExponentVariableExpr(Representation repr) {
+        this(repr.str().get());
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof BasicNamedExponentVariableExpr)) return false;
+        BasicNamedExponentVariableExpr that = (BasicNamedExponentVariableExpr) o;
+        return name.equals(that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name);
+    }
+
+    @Override
+    public Representation getRepresentation() {
+        return new StringRepresentation(name);
+    }
+
+    @Override
+    public ByteAccumulator updateAccumulator(ByteAccumulator accumulator) {
+        accumulator.append(name);
+        return accumulator;
+    }
+}

--- a/src/main/java/de/upb/crypto/math/expressions/exponent/ExponentConstantExpr.java
+++ b/src/main/java/de/upb/crypto/math/expressions/exponent/ExponentConstantExpr.java
@@ -1,6 +1,7 @@
 package de.upb.crypto.math.expressions.exponent;
 
 import de.upb.crypto.math.expressions.Expression;
+import de.upb.crypto.math.expressions.Substitution;
 import de.upb.crypto.math.expressions.VariableExpression;
 import de.upb.crypto.math.structures.zn.Zn;
 
@@ -40,8 +41,13 @@ public class ExponentConstantExpr implements ExponentExpr {
     }
 
     @Override
-    public ExponentExpr substitute(Function<VariableExpression, ? extends Expression> substitutions) {
+    public ExponentExpr substitute(Substitution substitutions) {
         return this;
+    }
+
+    @Override
+    public ExponentSumExpr linearize() throws IllegalArgumentException {
+        return new ExponentSumExpr(this, new ExponentEmptyExpr());
     }
 
     @Override

--- a/src/main/java/de/upb/crypto/math/expressions/exponent/ExponentEmptyExpr.java
+++ b/src/main/java/de/upb/crypto/math/expressions/exponent/ExponentEmptyExpr.java
@@ -1,6 +1,7 @@
 package de.upb.crypto.math.expressions.exponent;
 
 import de.upb.crypto.math.expressions.Expression;
+import de.upb.crypto.math.expressions.Substitution;
 import de.upb.crypto.math.expressions.VariableExpression;
 import de.upb.crypto.math.structures.zn.Zn;
 
@@ -31,7 +32,7 @@ public class ExponentEmptyExpr implements ExponentExpr {
     }
 
     @Override
-    public ExponentExpr substitute(Function<VariableExpression, ? extends Expression> substitutions) {
+    public ExponentExpr substitute(Substitution substitutions) {
         return this;
     }
 
@@ -43,6 +44,11 @@ public class ExponentEmptyExpr implements ExponentExpr {
     @Override
     public ExponentExpr mul(ExponentExpr other) {
         return this;
+    }
+
+    @Override
+    public ExponentSumExpr linearize() throws IllegalArgumentException {
+        return new ExponentSumExpr(this, this);
     }
 
     @Override

--- a/src/main/java/de/upb/crypto/math/expressions/exponent/ExponentExpr.java
+++ b/src/main/java/de/upb/crypto/math/expressions/exponent/ExponentExpr.java
@@ -1,13 +1,15 @@
 package de.upb.crypto.math.expressions.exponent;
 
 import de.upb.crypto.math.expressions.Expression;
-import de.upb.crypto.math.expressions.ValueBundle;
+import de.upb.crypto.math.expressions.Substitution;
 import de.upb.crypto.math.expressions.VariableExpression;
+import de.upb.crypto.math.expressions.bool.BooleanExpression;
 import de.upb.crypto.math.expressions.bool.ExponentEqualityExpr;
+import de.upb.crypto.math.expressions.group.GroupOpExpr;
+import de.upb.crypto.math.interfaces.structures.RingElement;
 import de.upb.crypto.math.structures.zn.Zn;
 
 import java.math.BigInteger;
-import java.util.function.Function;
 
 /**
  * An {@link Expression} that evaluates to an integer.
@@ -24,7 +26,7 @@ public interface ExponentExpr extends Expression {
     Zn.ZnElement evaluate(Zn zn);
 
     @Override
-    default BigInteger evaluate(Function<VariableExpression, ? extends Expression> substitutions) {
+    default BigInteger evaluate(Substitution substitutions) {
         return substitute(substitutions).evaluate();
     }
 
@@ -35,7 +37,7 @@ public interface ExponentExpr extends Expression {
      * @param substitutions a function mapping variables to expressions that can be evaluated
      * @return the result of evaluating this expression as a {@link Zn.ZnElement}
      */
-    default Zn.ZnElement evaluate(Zn zn, Function<VariableExpression, ? extends Expression> substitutions) {
+    default Zn.ZnElement evaluate(Zn zn, Substitution substitutions) {
         return substitute(substitutions).evaluate(zn);
     }
 
@@ -45,12 +47,12 @@ public interface ExponentExpr extends Expression {
     }
 
     @Override
-    ExponentExpr substitute(Function<VariableExpression, ? extends Expression> substitutions);
+    default ExponentExpr substitute(VariableExpression variable, Expression substitution) {
+        return (ExponentExpr) Expression.super.substitute(variable, substitution);
+    }
 
     @Override
-    default ExponentExpr substitute(ValueBundle values) {
-        return (ExponentExpr) Expression.super.substitute(values);
-    }
+    ExponentExpr substitute(Substitution substitutions);
 
     /**
      * Negates this expression.
@@ -77,13 +79,17 @@ public interface ExponentExpr extends Expression {
         return new ExponentSumExpr(this, other);
     }
 
+    default ExponentExpr add(Zn.ZnElement other) {
+        return add(other.asExponentExpression());
+    }
+
     /**
      * Adds an {@link ExponentVariableExpr} with the given variable name to this expression.
      * @param other the name of the variable to add
      * @return the result of adding the two expressions.
      */
     default ExponentExpr add(String other) {
-        return add(new ExponentVariableExpr(other));
+        return add(new BasicNamedExponentVariableExpr(other));
     }
 
     /**
@@ -96,6 +102,10 @@ public interface ExponentExpr extends Expression {
         return add(other.negate());
     }
 
+    default ExponentExpr sub(Zn.ZnElement other) {
+        return sub(other.asExponentExpression());
+    }
+
     /**
      * Subtracts a {@link ExponentVariableExpr} with the given variable name from this expression.
      * Realized by adding the negation.
@@ -103,7 +113,7 @@ public interface ExponentExpr extends Expression {
      * @return the result of subtraction
      */
     default ExponentExpr sub(String other) {
-        return sub(new ExponentVariableExpr(other));
+        return sub(new BasicNamedExponentVariableExpr(other));
     }
 
     /**
@@ -124,6 +134,8 @@ public interface ExponentExpr extends Expression {
         return mul(new ExponentConstantExpr(other));
     }
 
+    default ExponentExpr mul(RingElement other) { return mul(other.asInteger()); }
+
     /**
      * Multiplies this expression with the given constant.
      * @param other the factor
@@ -139,7 +151,7 @@ public interface ExponentExpr extends Expression {
      * @return the result of multiplication
      */
     default ExponentExpr mul(String other) {
-        return mul(new ExponentVariableExpr(other));
+        return mul(new BasicNamedExponentVariableExpr(other));
     }
 
     /**
@@ -169,13 +181,17 @@ public interface ExponentExpr extends Expression {
         return pow(new ExponentConstantExpr(exponent));
     }
 
+    default ExponentExpr pow(RingElement exponent) {
+        return pow(exponent.asInteger());
+    }
+
     /**
      * Raises this expression to the power variable with the given name.
      * @param exponent the name of the power variable
      * @return the result of the exponentiation
      */
     default ExponentExpr pow(String exponent) {
-        return pow(new ExponentVariableExpr(exponent));
+        return pow(new BasicNamedExponentVariableExpr(exponent));
     }
 
     /**
@@ -198,4 +214,17 @@ public interface ExponentExpr extends Expression {
     default ExponentEqualityExpr isEqualTo(BigInteger other) {
         return new ExponentEqualityExpr(this, new ExponentConstantExpr(other));
     }
+
+
+    /**
+     * Returns an equivalent expression of the form y + f(variables), where y is constant (no variables), and the expression f is linear, which means that
+     * f(variables) + f(variables2) = f(variables + variables2)
+     *
+     * The exact result is a ExponentSumExpr
+     * where the left-hand-side y has !y.containsVariables(),
+     * the right-hand-side is linear
+     *
+     * @throws IllegalArgumentException if it's not possible to form the desired output (e.g., the input is something like g^(x_1 * x_2) for variables x_1, x_2).
+     */
+    ExponentSumExpr linearize() throws IllegalArgumentException;
 }

--- a/src/main/java/de/upb/crypto/math/expressions/exponent/ExponentExpr.java
+++ b/src/main/java/de/upb/crypto/math/expressions/exponent/ExponentExpr.java
@@ -217,14 +217,17 @@ public interface ExponentExpr extends Expression {
 
 
     /**
-     * Returns an equivalent expression of the form y + f(variables), where y is constant (no variables), and the expression f is linear, which means that
+     * Returns an equivalent expression of the form {@code y + f(variables)}, where {@code y} is constant (no variables),
+     * and the expression {@code f} is linear.
+     * Linearity means that
+     * <pre>
      * f(variables) + f(variables2) = f(variables + variables2)
+     * </pre>
+     * The exact result is a {@code ExponentSumExpr} where the left-hand-side {@code y} fulfills
+     * {@code y.containsVariables() == false} and the right-hand side is linear.
      *
-     * The exact result is a ExponentSumExpr
-     * where the left-hand-side y has !y.containsVariables(),
-     * the right-hand-side is linear
-     *
-     * @throws IllegalArgumentException if it's not possible to form the desired output (e.g., the input is something like g^(x_1 * x_2) for variables x_1, x_2).
+     * @throws IllegalArgumentException if it's not possible to form the desired output
+     * (e.g., the input is something like \(g^{x_1 \cdot x_2}\) for variables \(x_1, x_2\)).
      */
     ExponentSumExpr linearize() throws IllegalArgumentException;
 }

--- a/src/main/java/de/upb/crypto/math/expressions/exponent/ExponentInvExpr.java
+++ b/src/main/java/de/upb/crypto/math/expressions/exponent/ExponentInvExpr.java
@@ -1,6 +1,7 @@
 package de.upb.crypto.math.expressions.exponent;
 
 import de.upb.crypto.math.expressions.Expression;
+import de.upb.crypto.math.expressions.Substitution;
 import de.upb.crypto.math.expressions.VariableExpression;
 import de.upb.crypto.math.structures.zn.Zn;
 
@@ -39,8 +40,16 @@ public class ExponentInvExpr implements ExponentExpr {
     }
 
     @Override
-    public ExponentExpr substitute(Function<VariableExpression, ? extends Expression> substitutions) {
+    public ExponentExpr substitute(Substitution substitutions) {
         return child.substitute(substitutions).invert();
+    }
+
+    @Override
+    public ExponentSumExpr linearize() throws IllegalArgumentException {
+        if (child.containsVariables())
+            throw new IllegalArgumentException("Cannot linearize - inversion of variables isn't linear");
+
+        return new ExponentSumExpr(this, new ExponentEmptyExpr());
     }
 
     @Override

--- a/src/main/java/de/upb/crypto/math/expressions/exponent/ExponentMulExpr.java
+++ b/src/main/java/de/upb/crypto/math/expressions/exponent/ExponentMulExpr.java
@@ -1,12 +1,11 @@
 package de.upb.crypto.math.expressions.exponent;
 
 import de.upb.crypto.math.expressions.Expression;
-import de.upb.crypto.math.expressions.VariableExpression;
+import de.upb.crypto.math.expressions.Substitution;
 import de.upb.crypto.math.structures.zn.Zn;
 
 import java.math.BigInteger;
 import java.util.function.Consumer;
-import java.util.function.Function;
 
 /**
  * An {@link ExponentExpr} represening the multiplication of two exponent expressions.
@@ -58,7 +57,27 @@ public class ExponentMulExpr implements ExponentExpr {
     }
 
     @Override
-    public ExponentExpr substitute(Function<VariableExpression, ? extends Expression> substitutions) {
+    public ExponentExpr substitute(Substitution substitutions) {
         return lhs.substitute(substitutions).mul(rhs.substitute(substitutions));
+    }
+
+    @Override
+    public ExponentSumExpr linearize() throws IllegalArgumentException {
+        boolean lhsHasVariables = lhs.containsVariables();
+        boolean rhsHasVariables = rhs.containsVariables();
+
+        if (lhsHasVariables && rhsHasVariables)
+            throw new IllegalArgumentException("Expression is not linear (it's of the form a*b where both a and b depend on variables)");
+
+        if (!lhsHasVariables && !rhsHasVariables)
+            return new ExponentSumExpr(this, new ExponentEmptyExpr());
+
+        if (lhsHasVariables) { //hence rhs doesn't
+            ExponentSumExpr lhsLinearized = lhs.linearize();
+            return new ExponentSumExpr(lhsLinearized.getLhs().mul(rhs), lhsLinearized.getRhs().mul(rhs));
+        } else { //lhs is constant, rhs isn't
+            ExponentSumExpr rhsLinearized = rhs.linearize();
+            return new ExponentSumExpr(lhs.mul(rhsLinearized.getLhs()), lhs.mul(rhsLinearized.getRhs()));
+        }
     }
 }

--- a/src/main/java/de/upb/crypto/math/expressions/exponent/ExponentNegExpr.java
+++ b/src/main/java/de/upb/crypto/math/expressions/exponent/ExponentNegExpr.java
@@ -1,12 +1,11 @@
 package de.upb.crypto.math.expressions.exponent;
 
 import de.upb.crypto.math.expressions.Expression;
-import de.upb.crypto.math.expressions.VariableExpression;
+import de.upb.crypto.math.expressions.Substitution;
 import de.upb.crypto.math.structures.zn.Zn;
 
 import java.math.BigInteger;
 import java.util.function.Consumer;
-import java.util.function.Function;
 
 /**
  * An {@link ExponentExpr} representing the negation of an exponent expression.
@@ -44,8 +43,14 @@ public class ExponentNegExpr implements ExponentExpr {
     }
 
     @Override
-    public ExponentExpr substitute(Function<VariableExpression, ? extends Expression> substitutions) {
+    public ExponentExpr substitute(Substitution substitutions) {
         return child.substitute(substitutions).negate();
+    }
+
+    @Override
+    public ExponentSumExpr linearize() throws IllegalArgumentException {
+        ExponentSumExpr childLinearized = child.linearize();
+        return new ExponentSumExpr(childLinearized.getLhs().negate(), childLinearized.getRhs().negate());
     }
 
 }

--- a/src/main/java/de/upb/crypto/math/expressions/exponent/ExponentPowExpr.java
+++ b/src/main/java/de/upb/crypto/math/expressions/exponent/ExponentPowExpr.java
@@ -1,6 +1,7 @@
 package de.upb.crypto.math.expressions.exponent;
 
 import de.upb.crypto.math.expressions.Expression;
+import de.upb.crypto.math.expressions.Substitution;
 import de.upb.crypto.math.expressions.VariableExpression;
 import de.upb.crypto.math.structures.zn.Zn;
 
@@ -58,8 +59,18 @@ public class ExponentPowExpr implements ExponentExpr {
     }
 
     @Override
-    public ExponentExpr substitute(Function<VariableExpression, ? extends Expression> substitutions) {
+    public ExponentExpr substitute(Substitution substitutions) {
         return base.substitute(substitutions).pow(exponent.substitute(substitutions));
+    }
+
+    @Override
+    public ExponentSumExpr linearize() throws IllegalArgumentException {
+        if (exponent.containsVariables())
+            throw new IllegalArgumentException("Cannot linearize expression a^b, where b contains variables.");
+        if (base.containsVariables())
+            throw new IllegalArgumentException("Cannot linearize expression a^b, where a contains variables.");
+
+        return new ExponentSumExpr(this, new ExponentEmptyExpr());
     }
 
 }

--- a/src/main/java/de/upb/crypto/math/expressions/exponent/ExponentSumExpr.java
+++ b/src/main/java/de/upb/crypto/math/expressions/exponent/ExponentSumExpr.java
@@ -1,6 +1,7 @@
 package de.upb.crypto.math.expressions.exponent;
 
 import de.upb.crypto.math.expressions.Expression;
+import de.upb.crypto.math.expressions.Substitution;
 import de.upb.crypto.math.expressions.VariableExpression;
 import de.upb.crypto.math.structures.zn.Zn;
 
@@ -58,8 +59,16 @@ public class ExponentSumExpr implements ExponentExpr {
     }
 
     @Override
-    public ExponentExpr substitute(Function<VariableExpression, ? extends Expression> substitutions) {
+    public ExponentExpr substitute(Substitution substitutions) {
         return lhs.substitute(substitutions).add(rhs.substitute(substitutions));
+    }
+
+    @Override
+    public ExponentSumExpr linearize() throws IllegalArgumentException {
+        ExponentSumExpr lhsLinearized = lhs.linearize();
+        ExponentSumExpr rhsLinearized = rhs.linearize();
+
+        return new ExponentSumExpr(lhsLinearized.getLhs().add(rhsLinearized.getLhs()), lhsLinearized.getRhs().add(rhsLinearized.getRhs()));
     }
 
 }

--- a/src/main/java/de/upb/crypto/math/expressions/exponent/ExponentVariableExpr.java
+++ b/src/main/java/de/upb/crypto/math/expressions/exponent/ExponentVariableExpr.java
@@ -12,58 +12,48 @@ import java.util.function.Function;
 /**
  * An {@link ExponentExpr} representing a named variable.
  */
-public class ExponentVariableExpr implements ExponentExpr, VariableExpression {
-
-    /**
-     * The name of this variable.
-     */
-    protected final String name;
-
-    public ExponentVariableExpr(String name) {
-        this.name = name;
-    }
-
+public interface ExponentVariableExpr extends ExponentExpr, VariableExpression {
     @Override
-    public BigInteger evaluate() {
+    default BigInteger evaluate() {
         throw new EvaluationException(this, "Variable cannot be evaluated");
     }
 
     @Override
-    public void forEachChild(Consumer<Expression> action) {
+    default void forEachChild(Consumer<Expression> action) {
         //Nothing to do
     }
 
     @Override
-    public Zn.ZnElement evaluate(Zn zn) {
+    default Zn.ZnElement evaluate(Zn zn) {
         throw new EvaluationException(this, "Variable cannot be evaluated");
     }
 
     @Override
-    public BigInteger evaluate(Function<VariableExpression, ? extends Expression> substitutions) {
-        ExponentExpr substitution = (ExponentExpr) substitutions.apply(this);
+    default BigInteger evaluate(Substitution substitutions) {
+        ExponentExpr substitution = (ExponentExpr) substitutions.getSubstitution(this);
         if (substitution == null)
             throw new EvaluationException(this, "Variable cannot be evaluated");
         return substitution.evaluate();
     }
 
     @Override
-    public Zn.ZnElement evaluate(Zn zn, Function<VariableExpression, ? extends Expression> substitutions) {
-        ExponentExpr substitution = (ExponentExpr) substitutions.apply(this);
+    default Zn.ZnElement evaluate(Zn zn, Substitution substitutions) {
+        ExponentExpr substitution = (ExponentExpr) substitutions.getSubstitution(this);
         if (substitution == null)
             throw new EvaluationException(this, "Variable cannot be evaluated");
         return substitution.evaluate(zn);
     }
 
     @Override
-    public ExponentExpr substitute(Function<VariableExpression, ? extends Expression> substitutions) {
-        Expression replacement = substitutions.apply(this);
+    default ExponentExpr substitute(Substitution substitutions) {
+        Expression replacement = substitutions.getSubstitution(this);
         if (replacement != null)
             return (ExponentExpr) replacement;
         return this;
     }
 
     @Override
-    public String getName() {
-        return name;
+    default ExponentSumExpr linearize() throws IllegalArgumentException {
+        return new ExponentSumExpr(new ExponentEmptyExpr(), this);
     }
 }

--- a/src/main/java/de/upb/crypto/math/expressions/exponent/ExponentVariableExpr.java
+++ b/src/main/java/de/upb/crypto/math/expressions/exponent/ExponentVariableExpr.java
@@ -2,6 +2,7 @@ package de.upb.crypto.math.expressions.exponent;
 
 import de.upb.crypto.math.expressions.EvaluationException;
 import de.upb.crypto.math.expressions.Expression;
+import de.upb.crypto.math.expressions.Substitution;
 import de.upb.crypto.math.expressions.VariableExpression;
 import de.upb.crypto.math.structures.zn.Zn;
 

--- a/src/main/java/de/upb/crypto/math/expressions/group/AbstractGroupElementExpression.java
+++ b/src/main/java/de/upb/crypto/math/expressions/group/AbstractGroupElementExpression.java
@@ -1,0 +1,47 @@
+package de.upb.crypto.math.expressions.group;
+
+import de.upb.crypto.math.expressions.Expression;
+import de.upb.crypto.math.expressions.Substitution;
+import de.upb.crypto.math.expressions.VariableExpression;
+import de.upb.crypto.math.expressions.bool.GroupEqualityExpr;
+import de.upb.crypto.math.expressions.exponent.ExponentConstantExpr;
+import de.upb.crypto.math.expressions.exponent.ExponentExpr;
+import de.upb.crypto.math.expressions.exponent.ExponentVariableExpr;
+import de.upb.crypto.math.interfaces.structures.Group;
+import de.upb.crypto.math.interfaces.structures.GroupElement;
+import de.upb.crypto.math.structures.zn.Zn;
+
+import java.math.BigInteger;
+
+/**
+ * {@link Expression} that evaluates to a {@link GroupElement}.
+ */
+public abstract class AbstractGroupElementExpression implements GroupElementExpression {
+    /**
+     * This expression evaluates to an element of this group.
+     */
+    protected final Group group;
+
+    public AbstractGroupElementExpression() {this(null);}
+
+    public AbstractGroupElementExpression(Group group) {
+        this.group = group;
+    }
+
+    /**
+     * Returns the group s.t. this expression evaluates to an element of this group, or null if group is unknown
+     * (e.g., if expression consists only of variables)
+     */
+    @Override
+    public Group getGroup() {
+        return group;
+    }
+
+    protected BigInteger getGroupOrderIfKnown() {
+        try {
+            return getGroup().size();
+        } catch (UnsupportedOperationException unknownSizeException) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/de/upb/crypto/math/expressions/group/AbstractGroupElementExpression.java
+++ b/src/main/java/de/upb/crypto/math/expressions/group/AbstractGroupElementExpression.java
@@ -14,7 +14,7 @@ import de.upb.crypto.math.structures.zn.Zn;
 import java.math.BigInteger;
 
 /**
- * {@link Expression} that evaluates to a {@link GroupElement}.
+ * An {@link Expression} that evaluates to a {@link GroupElement}.
  */
 public abstract class AbstractGroupElementExpression implements GroupElementExpression {
     /**
@@ -29,8 +29,8 @@ public abstract class AbstractGroupElementExpression implements GroupElementExpr
     }
 
     /**
-     * Returns the group s.t. this expression evaluates to an element of this group, or null if group is unknown
-     * (e.g., if expression consists only of variables)
+     * Returns the group such that this expression evaluates to an element of this group, or null if group is unknown
+     * (for example, if expression consists only of variables).
      */
     @Override
     public Group getGroup() {

--- a/src/main/java/de/upb/crypto/math/expressions/group/BasicNamedGroupVariableExpr.java
+++ b/src/main/java/de/upb/crypto/math/expressions/group/BasicNamedGroupVariableExpr.java
@@ -1,0 +1,50 @@
+package de.upb.crypto.math.expressions.group;
+
+import de.upb.crypto.math.interfaces.hash.ByteAccumulator;
+import de.upb.crypto.math.interfaces.hash.UniqueByteRepresentable;
+import de.upb.crypto.math.serialization.Representable;
+import de.upb.crypto.math.serialization.Representation;
+import de.upb.crypto.math.serialization.StringRepresentation;
+
+import javax.annotation.Nonnull;
+import java.util.Objects;
+
+public final class BasicNamedGroupVariableExpr implements GroupVariableExpr, Representable, UniqueByteRepresentable {
+    protected final String name;
+
+    public BasicNamedGroupVariableExpr(@Nonnull String name) {
+        this.name = name;
+    }
+
+    public BasicNamedGroupVariableExpr(Representation repr) {
+        this(repr.str().get());
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof BasicNamedGroupVariableExpr)) return false;
+        BasicNamedGroupVariableExpr that = (BasicNamedGroupVariableExpr) o;
+        return name.equals(that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name);
+    }
+
+    @Override
+    public Representation getRepresentation() {
+        return new StringRepresentation(name);
+    }
+
+    @Override
+    public ByteAccumulator updateAccumulator(ByteAccumulator accumulator) {
+        accumulator.append(name);
+        return accumulator;
+    }
+}

--- a/src/main/java/de/upb/crypto/math/expressions/group/BasicNamedGroupVariableExpr.java
+++ b/src/main/java/de/upb/crypto/math/expressions/group/BasicNamedGroupVariableExpr.java
@@ -9,7 +9,14 @@ import de.upb.crypto.math.serialization.StringRepresentation;
 import javax.annotation.Nonnull;
 import java.util.Objects;
 
+/**
+ * A {@link GroupVariableExpr} with a specific name.
+ */
 public final class BasicNamedGroupVariableExpr implements GroupVariableExpr, Representable, UniqueByteRepresentable {
+
+    /**
+     * The name of this variable expression.
+     */
     protected final String name;
 
     public BasicNamedGroupVariableExpr(@Nonnull String name) {

--- a/src/main/java/de/upb/crypto/math/expressions/group/GroupElementConstantExpr.java
+++ b/src/main/java/de/upb/crypto/math/expressions/group/GroupElementConstantExpr.java
@@ -1,7 +1,7 @@
 package de.upb.crypto.math.expressions.group;
 
 import de.upb.crypto.math.expressions.Expression;
-import de.upb.crypto.math.expressions.VariableExpression;
+import de.upb.crypto.math.expressions.Substitution;
 import de.upb.crypto.math.expressions.exponent.ExponentExpr;
 import de.upb.crypto.math.interfaces.structures.GroupElement;
 import de.upb.crypto.math.structures.zn.Zn;
@@ -9,15 +9,10 @@ import de.upb.crypto.math.structures.zn.Zn;
 import javax.annotation.Nonnull;
 import java.math.BigInteger;
 import java.util.function.Consumer;
-import java.util.function.Function;
-
 /**
  * A {@link GroupElementExpression} representing a constant group element.
  */
-public class GroupElementConstantExpr extends GroupElementExpression {
-    /**
-     * The constant value represented by this expression.
-     */
+public class GroupElementConstantExpr extends AbstractGroupElementExpression {
     protected final GroupElement value;
 
     public GroupElementConstantExpr(@Nonnull GroupElement value) {
@@ -31,17 +26,22 @@ public class GroupElementConstantExpr extends GroupElementExpression {
     }
 
     @Override
-    public GroupElement evaluate(Function<VariableExpression, ? extends Expression> substitutions) {
+    public GroupElement evaluate(Substitution substitutions) {
         return value;
     }
 
     @Override
-    public GroupElementExpression substitute(Function<VariableExpression, ? extends Expression> substitutions) {
+    public GroupElementExpression substitute(Substitution substitutions) {
         return this;
     }
 
     @Override
-    protected GroupOpExpr linearize(ExponentExpr exponent) {
+    public GroupOpExpr linearize() throws IllegalArgumentException {
+        return new GroupOpExpr(this, new GroupEmptyExpr(value.getStructure()));
+    }
+
+    @Override
+    public GroupOpExpr flatten(ExponentExpr exponent) {
         if (exponent.containsVariables()) {
             return new GroupOpExpr(new GroupEmptyExpr(getGroup()), this.pow(exponent));
         } else {

--- a/src/main/java/de/upb/crypto/math/expressions/group/GroupElementExpression.java
+++ b/src/main/java/de/upb/crypto/math/expressions/group/GroupElementExpression.java
@@ -61,34 +61,60 @@ public interface GroupElementExpression extends Expression {
         return pow(new BasicNamedExponentVariableExpr(exponent));
     }
 
+    /**
+     * Applies the group operation to this expression and the given expression raised to the given power.
+     */
     default GroupElementExpression opPow(GroupElementExpression rhs, ExponentExpr exponentOfRhs) {
         return op(rhs.pow(exponentOfRhs));
     }
 
+    /**
+     * Applies the group operation to this expression and the given expression raised to the given power.
+     */
     default GroupElementExpression opPow(GroupElementExpression rhs, BigInteger exponentOfRhs) {
         return op(rhs.pow(new ExponentConstantExpr(exponentOfRhs)));
     }
 
+    /**
+     * Applies the group operation to this expression and the given expression raised to the given power.
+     */
     default GroupElementExpression opPow(GroupElementExpression rhs, Zn.ZnElement exponentOfRhs) {
         return op(rhs.pow(new ExponentConstantExpr(exponentOfRhs)));
     }
 
+    /**
+     * Applies the group operation to this expression and the given expression raised to the given power variable.
+     * @param exponentOfRhs the power variable's name
+     */
     default GroupElementExpression opPow(GroupElementExpression rhs, String exponentOfRhs) {
         return op(rhs.pow(new BasicNamedExponentVariableExpr(exponentOfRhs)));
     }
 
+    /**
+     * Applies the group operation to this expression and the given group element raised to the given power.
+     */
     default GroupElementExpression opPow(GroupElement rhs, ExponentExpr exponentOfRhs) {
         return op(rhs.expr().pow(exponentOfRhs));
     }
 
+    /**
+     * Applies the group operation to this expression and the given group element raised to the given power.
+     */
     default GroupElementExpression opPow(GroupElement rhs, BigInteger exponentOfRhs) {
         return op(rhs.expr().pow(new ExponentConstantExpr(exponentOfRhs)));
     }
 
+    /**
+     * Applies the group operation to this expression and the given group element raised to the given power.
+     */
     default GroupElementExpression opPow(GroupElement rhs, Zn.ZnElement exponentOfRhs) {
         return op(rhs.expr().pow(new ExponentConstantExpr(exponentOfRhs)));
     }
 
+    /**
+     * Applies the group operation to this expression and the given group element raised to the given power variable.
+     * @param exponentOfRhs the power variable's name
+     */
     default GroupElementExpression opPow(GroupElement rhs, String exponentOfRhs) {
         return op(rhs.expr().pow(new BasicNamedExponentVariableExpr(exponentOfRhs)));
     }
@@ -110,12 +136,13 @@ public interface GroupElementExpression extends Expression {
     }
 
     /**
-     * Returns the group s.t. this expression evaluates to an element of this group, or null if group is unknown
-     * (e.g., if expression consists only of variables)
+     * Returns the group such that this expression evaluates to an element of this group, or null if group is unknown
+     * (for example, if expression consists only of variables).
      */
     Group getGroup();
+
     /**
-     * Prepares this expression for more efficient evaluation by sacrifing memory instead similar to
+     * Prepares this expression for more efficient evaluation by sacrificing memory instead similar to
      * {@link GroupElement#precomputePow()}.
      * <p>
      * First linearizes this expression via {@link #linearize()} and then calls {@link GroupElement#precomputePow()}
@@ -137,30 +164,34 @@ public interface GroupElementExpression extends Expression {
     }
 
     /**
-     * Returns an equivalent expression of the form y * f(groupVariables, exponentVariables), where y is constant (no variables), and the expression f is linear, which means that
-     * f(groupVariables, exponentVariables) * f(groupVariables2, exponentVariables2) = f(groupVariables * groupVariables2, exponentVariables + exponentVariables2)
+     * Returns an equivalent expression of the form {@code y * f(groupVariables, exponentVariables)},
+     * where {@code y} is constant (no variables), and the expression {@code f} is linear.
+     * Linearity means that
+     * <pre>
+     * f(groupVariables, exponentVariables) * f(groupVariables2, exponentVariables2)
+     * = f(groupVariables * groupVariables2, exponentVariables + exponentVariables2)
+     * </pre>
+     * The exact result is a {@code GroupOpExpr} where the left-hand-side {@code y} fulfills
+     * {@code y.containsVariables() == false} and the right-hand side is linear.
      *
-     * The exact result is a GroupOpExpr
-     * where the left-hand-side y has !y.containsVariables(),
-     * the right-hand-side is linear
-     *
-     * @throws IllegalArgumentException if it's not possible to form the desired output (e.g., the input is something like g^(x_1 * x_2) for variables x_1, x_2).
+     * @throws IllegalArgumentException if it's not possible to form the desired output
+     * (e.g., the input is something like \(g^{x_1 \cdot x_2}\) for variables \(x_1, x_2\)).
      */
     GroupOpExpr linearize() throws IllegalArgumentException;
 
     /**
-     * Returns an equivalent expression of the form y * prod(g_i^x_i), where y doesn't contain any variables.
+     * Returns an equivalent expression of the form \(y \cdot \prod(g_i^{x_i})\), where \(y\) doesn't contain any variables.
      *
-     * The exact result is a GroupOpExpr
-     * where the left-hand-side is a GroupElementConstantExpr y and the right-hand-side is an expression tree
-     * where each inner nodes is a GroupOpExpr or a PairingExpr whose children are flattened.
+     * The exact result is a {@code GroupOpExpr}
+     * where the left-hand side is a {@code GroupElementConstantExpr} y and the right-hand side is an expression tree
+     * where each inner nodes is a {@code GroupOpExpr} or a {@code PairingExpr} whose children are flattened.
      */
     default GroupOpExpr flatten() {
         return flatten(new ExponentConstantExpr(BigInteger.ONE));
     }
 
     /**
-     * Linearizes the expression this^exponent.
+     * Linearizes the expression \(\text{this}^\text{exponent}\).
      */
     GroupOpExpr flatten(ExponentExpr exponent);
 }

--- a/src/main/java/de/upb/crypto/math/expressions/group/GroupElementExpression.java
+++ b/src/main/java/de/upb/crypto/math/expressions/group/GroupElementExpression.java
@@ -158,19 +158,6 @@ public interface GroupElementExpression extends Expression {
     default GroupOpExpr flatten() {
         return flatten(new ExponentConstantExpr(BigInteger.ONE));
     }
-    /**
-     * Retrieves the order of the group element's group if possible.
-     *
-     * @return the order as a {@link BigInteger} if possible, else null
-     */
-    protected BigInteger getGroupOrderIfKnown() {
-        try {
-            return getGroup().size();
-        } catch (UnsupportedOperationException unknownSizeException) {
-            return null;
-        }
-    }
-
 
     /**
      * Linearizes the expression this^exponent.

--- a/src/main/java/de/upb/crypto/math/expressions/group/GroupElementExpression.java
+++ b/src/main/java/de/upb/crypto/math/expressions/group/GroupElementExpression.java
@@ -1,207 +1,119 @@
 package de.upb.crypto.math.expressions.group;
 
 import de.upb.crypto.math.expressions.Expression;
-import de.upb.crypto.math.expressions.ValueBundle;
+import de.upb.crypto.math.expressions.Substitution;
 import de.upb.crypto.math.expressions.VariableExpression;
 import de.upb.crypto.math.expressions.bool.GroupEqualityExpr;
+import de.upb.crypto.math.expressions.exponent.BasicNamedExponentVariableExpr;
 import de.upb.crypto.math.expressions.exponent.ExponentConstantExpr;
 import de.upb.crypto.math.expressions.exponent.ExponentExpr;
-import de.upb.crypto.math.expressions.exponent.ExponentVariableExpr;
 import de.upb.crypto.math.interfaces.structures.Group;
 import de.upb.crypto.math.interfaces.structures.GroupElement;
 import de.upb.crypto.math.structures.zn.Zn;
 
 import java.math.BigInteger;
-import java.util.function.Function;
 
 /**
  * An {@link Expression} that evaluates to a {@link GroupElement}.
  */
-public abstract class GroupElementExpression implements Expression {
-    /**
-     * This expression evaluates to an element of this group.
-     */
-    protected final Group group;
+public interface GroupElementExpression extends Expression {
 
-    public GroupElementExpression() {this(null);}
-
-    public GroupElementExpression(Group group) {
-        this.group = group;
-    }
-
-    public GroupElement evaluate() {
+    default GroupElement evaluate() {
         return evaluate(x -> null);
     }
 
     @Override
-    public abstract GroupElement evaluate(Function<VariableExpression, ? extends Expression> substitutions);
+    GroupElement evaluate(Substitution substitutions);
 
     @Override
-    public abstract GroupElementExpression substitute(Function<VariableExpression, ? extends Expression> substitutions);
+    GroupElementExpression substitute(Substitution substitutions);
 
     @Override
-    public GroupElementExpression substitute(ValueBundle values) {
-        return (GroupElementExpression) Expression.super.substitute(values);
-    }
-
-    @Override
-    public GroupElementExpression substitute(String variable, Expression substitution) {
+    default GroupElementExpression substitute(String variable, Expression substitution) {
         return (GroupElementExpression) Expression.super.substitute(variable, substitution);
     }
 
-    /**
-     * Applies the group operation to this expression and the given expression.
-     */
-    public GroupElementExpression op(GroupElementExpression rhs) {
+    @Override
+    default GroupElementExpression substitute(VariableExpression variable, Expression substitution) {
+        return (GroupElementExpression) Expression.super.substitute(variable, substitution);
+    }
+
+    default GroupElementExpression op(GroupElementExpression rhs) {
         return new GroupOpExpr(this, rhs);
     }
-
-    /**
-     * Applies the group operation to this expression and the group expression
-     * implied by the given group element.
-     */
-    public GroupElementExpression op(GroupElement rhs) {
+    default GroupElementExpression op(GroupElement rhs) {
         return new GroupOpExpr(this, new GroupElementConstantExpr(rhs));
     }
-    /**
-     * Applies the group operation to this expression and the variable expression implied by the given variable name.
-     */
-    public GroupElementExpression op(String rhs) {
-        return new GroupOpExpr(this, new GroupVariableExpr(rhs));
+    default GroupElementExpression op(String rhs) {
+        return new GroupOpExpr(this, new BasicNamedGroupVariableExpr(rhs));
     }
 
-    /**
-     * Raises this expression to the given power.
-     * @param exponent the power in form of an {@link ExponentExpr}
-     * @return an expression representing this expression raised to the given power
-     */
-    public GroupElementExpression pow(ExponentExpr exponent) {
+    default GroupElementExpression pow(ExponentExpr exponent) {
         return new GroupPowExpr(this, exponent);
     }
-
-    /**
-     * Raises this expression to the given power.
-     * @param exponent the power in form of a {@link BigInteger}
-     * @return an expression representing this expression raised to the given power
-     */
-    public GroupElementExpression pow(BigInteger exponent) {
+    default GroupElementExpression pow(BigInteger exponent) {
         return pow(new ExponentConstantExpr(exponent));
     }
-
-    /**
-     * Raises this expression to the given power.
-     * @param exponent the power in form of a {@link Zn.ZnElement}
-     * @return an expression representing this expression raised to the given power
-     */
-    public GroupElementExpression pow(Zn.ZnElement exponent) {
+    default GroupElementExpression pow(Zn.ZnElement exponent) {
         return pow(new ExponentConstantExpr(exponent.getInteger()));
     }
-
-    /**
-     * Raises this expression to the given power variable.
-     * @param exponent the power variable's name
-     * @return an expression representing this expression raised to the given power variable
-     */
-    public GroupElementExpression pow(String exponent) {
-        return pow(new ExponentVariableExpr(exponent));
+    default GroupElementExpression pow(String exponent) {
+        return pow(new BasicNamedExponentVariableExpr(exponent));
     }
 
-    /**
-     * Applies the group operation to this expression and the given expression raised to the given power.
-     */
-    public GroupElementExpression opPow(GroupElementExpression rhs, ExponentExpr exponentOfRhs) {
+    default GroupElementExpression opPow(GroupElementExpression rhs, ExponentExpr exponentOfRhs) {
         return op(rhs.pow(exponentOfRhs));
     }
 
-    /**
-     * Applies the group operation to this expression and the given expression raised to the given power.
-     */
-    public GroupElementExpression opPow(GroupElementExpression rhs, BigInteger exponentOfRhs) {
+    default GroupElementExpression opPow(GroupElementExpression rhs, BigInteger exponentOfRhs) {
         return op(rhs.pow(new ExponentConstantExpr(exponentOfRhs)));
     }
 
-    /**
-     * Applies the group operation to this expression and the given expression raised to the given power.
-     */
-    public GroupElementExpression opPow(GroupElementExpression rhs, Zn.ZnElement exponentOfRhs) {
+    default GroupElementExpression opPow(GroupElementExpression rhs, Zn.ZnElement exponentOfRhs) {
         return op(rhs.pow(new ExponentConstantExpr(exponentOfRhs)));
     }
 
-    /**
-     * Applies the group operation to this expression and the given expression raised to the given power variable.
-     * @param exponentOfRhs the power variable's name
-     */
-    public GroupElementExpression opPow(GroupElementExpression rhs, String exponentOfRhs) {
-        return op(rhs.pow(new ExponentVariableExpr(exponentOfRhs)));
+    default GroupElementExpression opPow(GroupElementExpression rhs, String exponentOfRhs) {
+        return op(rhs.pow(new BasicNamedExponentVariableExpr(exponentOfRhs)));
     }
 
-    /**
-     * Applies the group operation to this expression and the given group element raised to the given power.
-     */
-    public GroupElementExpression opPow(GroupElement rhs, ExponentExpr exponentOfRhs) {
+    default GroupElementExpression opPow(GroupElement rhs, ExponentExpr exponentOfRhs) {
         return op(rhs.expr().pow(exponentOfRhs));
     }
 
-    /**
-     * Applies the group operation to this expression and the given group element raised to the given power.
-     */
-    public GroupElementExpression opPow(GroupElement rhs, BigInteger exponentOfRhs) {
+    default GroupElementExpression opPow(GroupElement rhs, BigInteger exponentOfRhs) {
         return op(rhs.expr().pow(new ExponentConstantExpr(exponentOfRhs)));
     }
 
-    /**
-     * Applies the group operation to this expression and the given group element raised to the given power.
-     */
-    public GroupElementExpression opPow(GroupElement rhs, Zn.ZnElement exponentOfRhs) {
+    default GroupElementExpression opPow(GroupElement rhs, Zn.ZnElement exponentOfRhs) {
         return op(rhs.expr().pow(new ExponentConstantExpr(exponentOfRhs)));
     }
 
-    /**
-     * Applies the group operation to this expression and the given group element raised to the given power variable.
-     * @param exponentOfRhs the power variable's name
-     */
-    public GroupElementExpression opPow(GroupElement rhs, String exponentOfRhs) {
-        return op(rhs.expr().pow(new ExponentVariableExpr(exponentOfRhs)));
+    default GroupElementExpression opPow(GroupElement rhs, String exponentOfRhs) {
+        return op(rhs.expr().pow(new BasicNamedExponentVariableExpr(exponentOfRhs)));
     }
 
-    /**
-     * Inverts this group expression.
-     */
-    public GroupElementExpression inv() {
+    default GroupElementExpression inv() {
         return new GroupInvExpr(this);
     }
 
-    /**
-     * Creates a {@link GroupEqualityExpr} of this expression and the argument.
-     */
-    public GroupEqualityExpr isEqualTo(GroupElementExpression other) {
+    default GroupEqualityExpr isEqualTo(GroupElementExpression other) {
         return new GroupEqualityExpr(this, other);
     }
 
-    /**
-     * Creates a {@link GroupEqualityExpr} of this expression and a {@link GroupElementConstantExpr} created from the
-     * argument.
-     */
-    public GroupEqualityExpr isEqualTo(GroupElement other) {
+    default GroupEqualityExpr isEqualTo(GroupElement other) {
         return new GroupEqualityExpr(this, other.expr());
     }
 
-    /**
-     * Creates a {@link GroupEqualityExpr} of this expression and a {@link GroupVariableExpr} created with the given
-     * name string.
-     */
-    public GroupEqualityExpr isEqualTo(String other) {
-        return isEqualTo(new GroupVariableExpr(other));
+    default GroupEqualityExpr isEqualTo(String other) {
+        return isEqualTo(new BasicNamedGroupVariableExpr(other));
     }
 
     /**
      * Returns the group s.t. this expression evaluates to an element of this group, or null if group is unknown
      * (e.g., if expression consists only of variables)
      */
-    public Group getGroup() {
-        return group;
-    }
-
+    Group getGroup();
     /**
      * Prepares this expression for more efficient evaluation by sacrifing memory instead similar to
      * {@link GroupElement#precomputePow()}.
@@ -210,10 +122,10 @@ public abstract class GroupElementExpression implements Expression {
      * on each {@code GroupElementConstantExpr} found in the base of each {@code GroupPowExpr} as these will be
      * exponentiated later and can use the precomputations.
      */
-    public GroupElementExpression precompute() {
-        GroupOpExpr linearized = linearize();
-        linearized.getLhs().evaluate().computeSync();
-        linearized.treeWalk(expr -> {
+    default GroupElementExpression precompute() {
+        GroupOpExpr flattened = flatten();
+        flattened.getLhs().evaluate().computeSync();
+        flattened.treeWalk(expr -> {
             if (expr instanceof GroupPowExpr) {
                 GroupElementExpression base = ((GroupPowExpr) expr).getBase();
                 if (base instanceof GroupElementConstantExpr)
@@ -221,29 +133,31 @@ public abstract class GroupElementExpression implements Expression {
             }
         });
 
-        return linearized;
+        return flattened;
     }
 
     /**
-     * Returns an equivalent expression of the form \(y \cdot \prod g_i^x_i\) where \(y\) doesn't contain any variables,
-     * but for every \(i\), \(g_i\) or \(x_i\) do.
-     * <p>
-     * The exact result is a {@code GroupOpExpr} where the left-hand-side is a {@code GroupElementConstantExpr y},
-     * the right-hand-side is a tree whose inner nodes are {@code GroupOpExpr} or {@code PairingExpr}
-     * and leaf nodes are {@code GroupPowExpr} (whose base is a {@code GroupConstantExpr}, a {@code GroupVariableExpr},
-     * or a {@code PairingExpr} whose arguments are again linearized).
+     * Returns an equivalent expression of the form y * f(groupVariables, exponentVariables), where y is constant (no variables), and the expression f is linear, which means that
+     * f(groupVariables, exponentVariables) * f(groupVariables2, exponentVariables2) = f(groupVariables * groupVariables2, exponentVariables + exponentVariables2)
+     *
+     * The exact result is a GroupOpExpr
+     * where the left-hand-side y has !y.containsVariables(),
+     * the right-hand-side is linear
+     *
+     * @throws IllegalArgumentException if it's not possible to form the desired output (e.g., the input is something like g^(x_1 * x_2) for variables x_1, x_2).
      */
-    public GroupOpExpr linearize() {
-        return linearize(new ExponentConstantExpr(BigInteger.ONE));
-    }
+    GroupOpExpr linearize() throws IllegalArgumentException;
 
     /**
-     * Linearizes the expression \(\text{this}^\text{exponent}\).
-     * The result must be an equivalent expression of form \(y \cdot \prod g_i^x_i\)
-     * where \(y\) doesn't contain any variables, but for every \(i\), \(g_i\) or \(x_i\) do.
+     * Returns an equivalent expression of the form y * prod(g_i^x_i), where y doesn't contain any variables.
+     *
+     * The exact result is a GroupOpExpr
+     * where the left-hand-side is a GroupElementConstantExpr y and the right-hand-side is an expression tree
+     * where each inner nodes is a GroupOpExpr or a PairingExpr whose children are flattened.
      */
-    protected abstract GroupOpExpr linearize(ExponentExpr exponent);
-
+    default GroupOpExpr flatten() {
+        return flatten(new ExponentConstantExpr(BigInteger.ONE));
+    }
     /**
      * Retrieves the order of the group element's group if possible.
      *
@@ -256,4 +170,10 @@ public abstract class GroupElementExpression implements Expression {
             return null;
         }
     }
+
+
+    /**
+     * Linearizes the expression this^exponent.
+     */
+    GroupOpExpr flatten(ExponentExpr exponent);
 }

--- a/src/main/java/de/upb/crypto/math/expressions/group/GroupEmptyExpr.java
+++ b/src/main/java/de/upb/crypto/math/expressions/group/GroupEmptyExpr.java
@@ -1,7 +1,7 @@
 package de.upb.crypto.math.expressions.group;
 
 import de.upb.crypto.math.expressions.Expression;
-import de.upb.crypto.math.expressions.VariableExpression;
+import de.upb.crypto.math.expressions.Substitution;
 import de.upb.crypto.math.expressions.exponent.ExponentExpr;
 import de.upb.crypto.math.interfaces.structures.Group;
 import de.upb.crypto.math.interfaces.structures.GroupElement;
@@ -9,21 +9,24 @@ import de.upb.crypto.math.structures.zn.Zn;
 
 import java.math.BigInteger;
 import java.util.function.Consumer;
-import java.util.function.Function;
 
 /**
  * Represents the neutral group element of the given group. Has utility over using a
  * {@link GroupElementConstantExpr} with a neutral element in the sense that the neutral element
  * is replaced on a group operation, leading to saving one potential group operation.
  */
-public class GroupEmptyExpr extends GroupElementExpression {
+public class GroupEmptyExpr extends AbstractGroupElementExpression {
 
     public GroupEmptyExpr(Group group) {
         super(group);
     }
 
+    public GroupEmptyExpr() {
+        super();
+    }
+
     @Override
-    public GroupElement evaluate(Function<VariableExpression, ? extends Expression> substitutions) {
+    public GroupElement evaluate(Substitution substitutions) {
         return this.group.getNeutralElement();
     }
 
@@ -33,7 +36,7 @@ public class GroupEmptyExpr extends GroupElementExpression {
     }
 
     @Override
-    public GroupElementExpression substitute(Function<VariableExpression, ? extends Expression> substitutions) {
+    public GroupElementExpression substitute(Substitution substitutions) {
         return this;
     }
 
@@ -68,7 +71,12 @@ public class GroupEmptyExpr extends GroupElementExpression {
     }
 
     @Override
-    protected GroupOpExpr linearize(ExponentExpr exponent) {
+    public GroupOpExpr linearize() throws IllegalArgumentException {
+        return new GroupOpExpr(this, this);
+    }
+
+    @Override
+    public GroupOpExpr flatten(ExponentExpr exponent) {
         return new GroupOpExpr(this, this);
     }
 }

--- a/src/main/java/de/upb/crypto/math/expressions/group/GroupInvExpr.java
+++ b/src/main/java/de/upb/crypto/math/expressions/group/GroupInvExpr.java
@@ -2,18 +2,17 @@ package de.upb.crypto.math.expressions.group;
 
 
 import de.upb.crypto.math.expressions.Expression;
-import de.upb.crypto.math.expressions.VariableExpression;
+import de.upb.crypto.math.expressions.Substitution;
 import de.upb.crypto.math.expressions.exponent.ExponentExpr;
+import de.upb.crypto.math.interfaces.structures.Group;
 import de.upb.crypto.math.interfaces.structures.GroupElement;
 
 import javax.annotation.Nonnull;
 import java.util.function.Consumer;
-import java.util.function.Function;
-
 /**
  * A {@link GroupElementExpression} representing the inversion of another group element expression.
  */
-public class GroupInvExpr extends GroupElementExpression {
+public class GroupInvExpr extends AbstractGroupElementExpression {
     protected GroupElementExpression base;
 
     public GroupInvExpr(@Nonnull GroupElementExpression base) {
@@ -34,12 +33,12 @@ public class GroupInvExpr extends GroupElementExpression {
     }
 
     @Override
-    public GroupElement evaluate(Function<VariableExpression, ? extends Expression> substitutions) {
+    public GroupElement evaluate(Substitution substitutions) {
         return base.evaluate(substitutions).inv();
     }
 
     @Override
-    public GroupElementExpression substitute(Function<VariableExpression, ? extends Expression> substitutions) {
+    public GroupElementExpression substitute(Substitution substitutions) {
         return base.substitute(substitutions).inv();
     }
 
@@ -49,7 +48,13 @@ public class GroupInvExpr extends GroupElementExpression {
     }
 
     @Override
-    protected GroupOpExpr linearize(ExponentExpr exponent) {
-        return base.linearize(exponent.negate());
+    public GroupOpExpr linearize() throws IllegalArgumentException {
+        GroupOpExpr baseLinear = base.linearize();
+        return new GroupOpExpr(baseLinear.getLhs().inv(), baseLinear.getRhs().inv());
+    }
+
+    @Override
+    public GroupOpExpr flatten(ExponentExpr exponent) {
+        return base.flatten(exponent.negate());
     }
 }

--- a/src/main/java/de/upb/crypto/math/expressions/group/GroupOpExpr.java
+++ b/src/main/java/de/upb/crypto/math/expressions/group/GroupOpExpr.java
@@ -1,18 +1,16 @@
 package de.upb.crypto.math.expressions.group;
 
 import de.upb.crypto.math.expressions.Expression;
-import de.upb.crypto.math.expressions.VariableExpression;
+import de.upb.crypto.math.expressions.Substitution;
 import de.upb.crypto.math.expressions.exponent.ExponentExpr;
 import de.upb.crypto.math.interfaces.structures.GroupElement;
 
 import java.util.function.Consumer;
-import java.util.function.Function;
-
 /**
  * A {@link GroupElementExpression} representing the group operation applied to two group element expressions.
  */
-public class GroupOpExpr extends GroupElementExpression {
-    private final GroupElementExpression lhs, rhs;
+public class GroupOpExpr extends AbstractGroupElementExpression {
+    protected GroupElementExpression lhs, rhs;
 
     public GroupOpExpr(GroupElementExpression lhs, GroupElementExpression rhs) {
         super(lhs.getGroup() != null ? lhs.getGroup() : rhs.getGroup());
@@ -26,7 +24,7 @@ public class GroupOpExpr extends GroupElementExpression {
     }
 
     @Override
-    public GroupElement evaluate(Function<VariableExpression, ? extends Expression> substitutions) {
+    public GroupElement evaluate(Substitution substitutions) {
         return lhs.evaluate(substitutions).op(rhs.evaluate(substitutions));
     }
 
@@ -37,17 +35,25 @@ public class GroupOpExpr extends GroupElementExpression {
     }
 
     @Override
-    public GroupElementExpression substitute(Function<VariableExpression, ? extends Expression> substitutions) {
+    public GroupElementExpression substitute(Substitution substitutions) {
         return lhs.substitute(substitutions).op(rhs.substitute(substitutions));
     }
 
     @Override
-    protected GroupOpExpr linearize(ExponentExpr exponent) {
-        GroupOpExpr lhsLinear = lhs.linearize(exponent);
-        GroupOpExpr rhsLinear = rhs.linearize(exponent);
+    public GroupOpExpr linearize() throws IllegalArgumentException {
+        GroupOpExpr lhsLinear = lhs.linearize();
+        GroupOpExpr rhsLinear = rhs.linearize();
+
+        return new GroupOpExpr(lhsLinear.getLhs().op(rhsLinear.getLhs()), lhsLinear.getRhs().op(rhsLinear.getRhs()));
+    }
+
+    @Override
+    public GroupOpExpr flatten(ExponentExpr exponent) {
+        GroupOpExpr lhsFlat = lhs.flatten(exponent);
+        GroupOpExpr rhsLinear = rhs.flatten(exponent);
         return new GroupOpExpr(
-                lhsLinear.getLhs().evaluate().op(rhsLinear.getLhs().evaluate()).expr(), //multiply the two y
-                lhsLinear.getRhs().op(rhsLinear.getRhs()) //multiply the two products that contain variables
+                lhsFlat.getLhs().evaluate().op(rhsLinear.getLhs().evaluate()).expr(), //multiply the two y
+                lhsFlat.getRhs().op(rhsLinear.getRhs()) //multiply the two products that contain variables
         );
     }
 

--- a/src/main/java/de/upb/crypto/math/expressions/group/GroupPowExpr.java
+++ b/src/main/java/de/upb/crypto/math/expressions/group/GroupPowExpr.java
@@ -1,18 +1,18 @@
 package de.upb.crypto.math.expressions.group;
 
 import de.upb.crypto.math.expressions.Expression;
-import de.upb.crypto.math.expressions.VariableExpression;
+import de.upb.crypto.math.expressions.Substitution;
 import de.upb.crypto.math.expressions.exponent.ExponentExpr;
+import de.upb.crypto.math.expressions.exponent.ExponentSumExpr;
+import de.upb.crypto.math.interfaces.structures.Group;
 import de.upb.crypto.math.interfaces.structures.GroupElement;
 
 import java.math.BigInteger;
 import java.util.function.Consumer;
-import java.util.function.Function;
-
 /**
  * A {@link GroupElementExpression} representing a a group element expression raised to some power.
  */
-public class GroupPowExpr extends GroupElementExpression {
+public class GroupPowExpr extends AbstractGroupElementExpression {
     protected GroupElementExpression base;
     protected ExponentExpr exponent;
 
@@ -23,7 +23,7 @@ public class GroupPowExpr extends GroupElementExpression {
     }
 
     @Override
-    public GroupElement evaluate(Function<VariableExpression, ? extends Expression> substitutions) {
+    public GroupElement evaluate(Substitution substitutions) {
         BigInteger groupOrder = getGroupOrderIfKnown();
 
         if (groupOrder == null)
@@ -39,7 +39,7 @@ public class GroupPowExpr extends GroupElementExpression {
     }
 
     @Override
-    public GroupElementExpression substitute(Function<VariableExpression, ? extends Expression> substitutions) {
+    public GroupElementExpression substitute(Substitution substitutions) {
         return base.substitute(substitutions).pow(exponent.substitute(substitutions));
     }
 
@@ -63,7 +63,27 @@ public class GroupPowExpr extends GroupElementExpression {
     }
 
     @Override
-    protected GroupOpExpr linearize(ExponentExpr exp) {
-        return base.linearize(exp.mul(this.exponent));
+    public GroupOpExpr linearize() throws IllegalArgumentException {
+        boolean baseHasVariables = base.containsVariables();
+        boolean exponentHasVariables = exponent.containsVariables();
+
+        if (baseHasVariables && exponentHasVariables)
+            throw new IllegalArgumentException("Cannot linearize this expression (it's of the form g^x, where both g and x depend on variables)");
+
+        if (!baseHasVariables && !exponentHasVariables)
+            return new GroupOpExpr(this, new GroupEmptyExpr(base.getGroup()));
+
+        if (baseHasVariables) { //hence exponent doesn't
+            GroupOpExpr baseLinear = base.linearize();
+            return new GroupOpExpr(baseLinear.getLhs().pow(exponent), baseLinear.getRhs().pow(exponent));
+        } else { //exponent has variables, base doesn't.
+            ExponentSumExpr exponentLinear = exponent.linearize();
+            return new GroupOpExpr(base.pow(exponentLinear.getLhs()), base.pow(exponentLinear.getRhs()));
+        }
+    }
+
+    @Override
+    public GroupOpExpr flatten(ExponentExpr exp) {
+        return base.flatten(exp.mul(this.exponent));
     }
 }

--- a/src/main/java/de/upb/crypto/math/expressions/group/GroupVariableExpr.java
+++ b/src/main/java/de/upb/crypto/math/expressions/group/GroupVariableExpr.java
@@ -2,57 +2,55 @@ package de.upb.crypto.math.expressions.group;
 
 import de.upb.crypto.math.expressions.EvaluationException;
 import de.upb.crypto.math.expressions.Expression;
+import de.upb.crypto.math.expressions.Substitution;
 import de.upb.crypto.math.expressions.VariableExpression;
 import de.upb.crypto.math.expressions.exponent.ExponentExpr;
+import de.upb.crypto.math.interfaces.structures.Group;
 import de.upb.crypto.math.interfaces.structures.GroupElement;
 
-import javax.annotation.Nonnull;
 import java.util.function.Consumer;
-import java.util.function.Function;
-
 /**
  * A {@link GroupElementExpression} representing a variable which does not have a known value at time of creation.
  */
-public class GroupVariableExpr extends GroupElementExpression implements VariableExpression {
-    protected final String name;
-
-    public GroupVariableExpr(@Nonnull String name) {
-        this.name = name;
-    }
-
+public interface GroupVariableExpr extends GroupElementExpression, VariableExpression {
     @Override
-    public GroupElement evaluate() {
+    default GroupElement evaluate() {
         throw new EvaluationException(this, "Variable cannot be evaluated");
     }
 
     @Override
-    public GroupElement evaluate(Function<VariableExpression, ? extends Expression> substitutions) {
-        GroupElementExpression substitution = (GroupElementExpression) substitutions.apply(this);
+    default GroupElement evaluate(Substitution substitutions) {
+        GroupElementExpression substitution = (GroupElementExpression) substitutions.getSubstitution(this);
         if (substitution == null)
             throw new EvaluationException(this, "Variable cannot be evaluated");
         return substitution.evaluate();
     }
 
     @Override
-    public GroupElementExpression substitute(Function<VariableExpression, ? extends Expression> substitutions) {
-        Expression replacement = substitutions.apply(this);
+    default GroupElementExpression substitute(Substitution substitutions) {
+        Expression replacement = substitutions.getSubstitution(this);
         if (replacement != null)
             return (GroupElementExpression) replacement;
         return this;
     }
 
     @Override
-    protected GroupOpExpr linearize(ExponentExpr exponent) {
+    default Group getGroup() {
+        return null; //unknown
+    }
+
+    @Override
+    default GroupOpExpr flatten(ExponentExpr exponent) {
         return new GroupOpExpr(new GroupEmptyExpr(getGroup()), this.pow(exponent));
     }
 
     @Override
-    public String getName() {
-        return name;
+    default void forEachChild(Consumer<Expression> action) {
+        //Nothing to do
     }
 
     @Override
-    public void forEachChild(Consumer<Expression> action) {
-        //Nothing to do
+    default GroupOpExpr linearize() throws IllegalArgumentException {
+        return new GroupOpExpr(new GroupEmptyExpr(), this);
     }
 }

--- a/src/main/java/de/upb/crypto/math/interfaces/hash/ByteAccumulator.java
+++ b/src/main/java/de/upb/crypto/math/interfaces/hash/ByteAccumulator.java
@@ -4,6 +4,7 @@ import de.upb.crypto.math.hash.impl.ByteArrayAccumulator;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 
 /**
  * A {@code ByteAccumulator} takes a (large) byte-string x as input and outputs a byte array
@@ -17,7 +18,7 @@ import java.nio.charset.StandardCharsets;
  * Usually, this class will be used in the context of the {@link UniqueByteRepresentable} interface.
  * To that end, it contains some helper methods to make it easier to insert certain x into this.
  */
-public abstract class ByteAccumulator {
+public abstract class ByteAccumulator implements Comparable<ByteAccumulator> {
     public static byte SEPARATOR = (byte) '\\';
 
     /**
@@ -138,5 +139,26 @@ public abstract class ByteAccumulator {
      */
     public void append(int integer) {
         append(ByteBuffer.allocate(4).putInt(integer).array());
+    }
+
+    /**
+     * Appends the given String encoded as UTF-8 to the accumulator
+     */
+    public void append(String str) {
+        append(str.getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Override
+    public int compareTo(ByteAccumulator byteAccumulator) {
+        byte[] thisArr = extractBytes();
+        byte[] theirArr = byteAccumulator.extractBytes();
+
+        //Let's go for lexicographic ordering
+        for (int i=0;i<Math.min(thisArr.length, theirArr.length);i++) {
+            if (thisArr[i] != theirArr[i])
+                return thisArr[i] < theirArr[i] ? -1 : 1;
+        }
+
+        return Integer.compare(thisArr.length, theirArr.length);
     }
 }

--- a/src/main/java/de/upb/crypto/math/interfaces/structures/GroupElement.java
+++ b/src/main/java/de/upb/crypto/math/interfaces/structures/GroupElement.java
@@ -1,6 +1,8 @@
 package de.upb.crypto.math.interfaces.structures;
 
+import de.upb.crypto.math.expressions.exponent.ExponentExpr;
 import de.upb.crypto.math.expressions.group.GroupElementConstantExpr;
+import de.upb.crypto.math.expressions.group.GroupElementExpression;
 import de.upb.crypto.math.interfaces.hash.UniqueByteRepresentable;
 import de.upb.crypto.math.structures.cartesian.GroupElementVector;
 import de.upb.crypto.math.structures.cartesian.Vector;
@@ -55,6 +57,14 @@ public interface GroupElement extends Element, UniqueByteRepresentable {
      */
     GroupElement op(Element e) throws IllegalArgumentException;
 
+    default GroupElementExpression op(GroupElementExpression e) {
+        return expr().op(e);
+    }
+
+    default GroupElementExpression op(String variable) {
+        return expr().op(variable);
+    }
+
     /**
      * Computes {@code this.op(this)}.
      * <p>
@@ -78,15 +88,20 @@ public interface GroupElement extends Element, UniqueByteRepresentable {
      * such that {@code getStructure().size()} divides n.
      */
     default GroupElement pow(ZnElement k) {
-        return pow(k.asExponent());
+        return pow((RingElement) k);
     }
 
     /**
      * Calculates the result of applying the group operation k times.
-     * Note that this is only well-defined if k has an integer-like structure (e.g., Zn).
+     * This is only well-defined if this.getStructure().size() divides k.getStructure().getCharacteristic()
+     * and k.asInteger() doesn't throw an exception.
      */
     default GroupElement pow(RingElement k) {
-        return pow(k.asExponent());
+        if (!getStructure().size().equals(k.getStructure().getCharacteristic())
+                && !k.getStructure().getCharacteristic().equals(BigInteger.ZERO)
+                && !getStructure().size().mod(k.getStructure().getCharacteristic()).equals(BigInteger.ZERO))
+            throw new IllegalArgumentException("Cannot raise to the power of "+k);
+        return pow(k.asInteger());
     }
 
     /**
@@ -104,11 +119,19 @@ public interface GroupElement extends Element, UniqueByteRepresentable {
 
     /**
      * Computes vector {@code (g.pow(exponents[0]), g.pow(exponents[1]), ...)}.
-     * @param exponents the exponents to use (BigInteger, Long, or ZnElements)
+     * @param exponents the exponents to use
      * @return {@code (g.pow(exponents[0]), g.pow(exponents[1]), ...)}
      */
     default GroupElementVector pow(Vector<? extends RingElement> exponents) {
         return GroupElementVector.generate(i -> this, exponents.length()).pow(exponents);
+    }
+
+    default GroupElementExpression pow(ExponentExpr exponent) {
+        return expr().pow(exponent);
+    }
+
+    default GroupElementExpression pow(String variable) {
+        return expr().pow(variable);
     }
 
     /**

--- a/src/main/java/de/upb/crypto/math/interfaces/structures/GroupElement.java
+++ b/src/main/java/de/upb/crypto/math/interfaces/structures/GroupElement.java
@@ -93,8 +93,8 @@ public interface GroupElement extends Element, UniqueByteRepresentable {
 
     /**
      * Calculates the result of applying the group operation k times.
-     * This is only well-defined if this.getStructure().size() divides k.getStructure().getCharacteristic()
-     * and k.asInteger() doesn't throw an exception.
+     * This is only well-defined if {@code this.getStructure().size()} divides {@code k.getStructure().getCharacteristic()}
+     * and {@code k.asInteger()} doesn't throw an exception.
      */
     default GroupElement pow(RingElement k) {
         if (!getStructure().size().equals(k.getStructure().getCharacteristic())

--- a/src/main/java/de/upb/crypto/math/interfaces/structures/RingElement.java
+++ b/src/main/java/de/upb/crypto/math/interfaces/structures/RingElement.java
@@ -205,16 +205,14 @@ public interface RingElement extends Element {
     }
 
     /**
-     * Interprets this element as an exponent for the given group.
-     * <p>
-     * For example, for a group of size n, {@code ZnElement} instances can usefully serve as exponents.
+     * Interprets this Element as an integer.
+     * Formally, this method shall return the inverse of Ring.getElement(BigInteger), i.e.
+     * x.getStructure().getElement(x.asInteger()).equals(x) (if asInteger() doesn't throw an exception).
      *
-     * @return a useful integer value such that the expression
-     *         {@code groupElement.pow(this).equals(groupElement.pow(this.asExponent())} makes sense
-     * @throws UnsupportedOperationException if elements of the ring are not fit to be interpreted
-     *                                       as exponents for a group
+     * @return the inverse of x -> ring.getElement(x);
+     * @throws UnsupportedOperationException if no such element exists or cannot be efficiently computed.
      */
-    default BigInteger asExponent() throws UnsupportedOperationException {
-        throw new UnsupportedOperationException("Cannot interpret "+getClass().getName()+" as an exponent");
+    default BigInteger asInteger() throws UnsupportedOperationException {
+        throw new UnsupportedOperationException("Cannot interpret "+getClass().getName()+" as an integer");
     }
 }

--- a/src/main/java/de/upb/crypto/math/interfaces/structures/RingElement.java
+++ b/src/main/java/de/upb/crypto/math/interfaces/structures/RingElement.java
@@ -205,12 +205,13 @@ public interface RingElement extends Element {
     }
 
     /**
-     * Interprets this Element as an integer.
-     * Formally, this method shall return the inverse of Ring.getElement(BigInteger), i.e.
-     * x.getStructure().getElement(x.asInteger()).equals(x) (if asInteger() doesn't throw an exception).
+     * Interprets this element as an integer.
+     * <p>
+     * Formally, this method shall return the inverse of {@link Ring#getElement(BigInteger)}, i.e.
+     * {@code x.getStructure().getElement(x.asInteger()).equals(x)} (if {@code asInteger()} doesn't throw an exception).
      *
-     * @return the inverse of x -> ring.getElement(x);
-     * @throws UnsupportedOperationException if no such element exists or cannot be efficiently computed.
+     * @return the integer corresponding to this element
+     * @throws UnsupportedOperationException if no such element exists or cannot be efficiently computed
      */
     default BigInteger asInteger() throws UnsupportedOperationException {
         throw new UnsupportedOperationException("Cannot interpret "+getClass().getName()+" as an integer");

--- a/src/main/java/de/upb/crypto/math/pairings/counting/CountingGroup.java
+++ b/src/main/java/de/upb/crypto/math/pairings/counting/CountingGroup.java
@@ -95,7 +95,7 @@ public class CountingGroup implements Group {
 
     @Override
     public GroupElement getElement(Representation repr) {
-        return new CountingGroupElement(repr);
+        return new CountingGroupElement(this, repr);
     }
 
     public CountingGroupElement wrap(Zn.ZnElement elem) {

--- a/src/main/java/de/upb/crypto/math/pairings/counting/CountingGroupElement.java
+++ b/src/main/java/de/upb/crypto/math/pairings/counting/CountingGroupElement.java
@@ -52,9 +52,9 @@ public class CountingGroupElement implements GroupElement {
         this.elemExpMultiExp = elemExpMultiExp;
     }
 
-    public CountingGroupElement(Representation repr) {
+    public CountingGroupElement(CountingGroup group, Representation repr) {
         ObjectRepresentation objRepr = repr.obj();
-        group = new CountingGroup(objRepr.get("group"));
+        this.group = group;
         elemTotal = (LazyGroupElement) group.groupTotal.getElement(objRepr.get("elemTotal"));
         elemExpMultiExp = (LazyGroupElement) group.groupExpMultiExp.getElement(objRepr.get("elemExpMultiExp"));
     }
@@ -62,7 +62,6 @@ public class CountingGroupElement implements GroupElement {
     @Override
     public Representation getRepresentation() {
         ObjectRepresentation repr = new ObjectRepresentation();
-        repr.put("group", group.getRepresentation());
         repr.put("elemTotal", elemTotal.getRepresentation());
         repr.put("elemExpMultiExp", elemExpMultiExp.getRepresentation());
         return repr;

--- a/src/main/java/de/upb/crypto/math/pairings/generic/BilinearMap.java
+++ b/src/main/java/de/upb/crypto/math/pairings/generic/BilinearMap.java
@@ -112,7 +112,7 @@ public interface BilinearMap extends BiFunction<GroupElement, GroupElement, Grou
      * @param g2elem the right hand side G2 group element expression argument for the pairing function
      * @return a {@code PairingExpr}
      */
-    default PairingExpr expr(GroupElementExpression g1elem, GroupElementExpression g2elem) {
+    default PairingExpr applyExpr(GroupElementExpression g1elem, GroupElementExpression g2elem) {
         return new PairingExpr(this, g1elem, g2elem);
     }
 
@@ -122,8 +122,16 @@ public interface BilinearMap extends BiFunction<GroupElement, GroupElement, Grou
      * @param g2elem the right hand side G2 element argument for the pairing function
      * @return a {@code PairingExpr}
      */
-    default PairingExpr expr(GroupElement g1elem, GroupElement g2elem) {
-        return expr(g1elem.expr(), g2elem.expr());
+    default PairingExpr applyExpr(GroupElement g1elem, GroupElement g2elem) {
+        return applyExpr(g1elem.expr(), g2elem.expr());
+    }
+
+    default PairingExpr applyExpr(GroupElement g1elem, GroupElementExpression g2elem) {
+        return applyExpr(g1elem.expr(), g2elem);
+    }
+
+    default PairingExpr applyExpr(GroupElementExpression g1elem, GroupElement g2elem) {
+        return applyExpr(g1elem, g2elem.expr());
     }
 
     /**

--- a/src/main/java/de/upb/crypto/math/pairings/generic/ExtensionFieldElement.java
+++ b/src/main/java/de/upb/crypto/math/pairings/generic/ExtensionFieldElement.java
@@ -248,4 +248,14 @@ public class ExtensionFieldElement implements FieldElement, UniqueByteRepresenta
         return accumulator;
 
     }
+
+    @Override
+    public BigInteger asInteger() throws UnsupportedOperationException {
+        if (coefficients.length == 0)
+            return BigInteger.ZERO;
+        for (int i=1;i<coefficients.length;i++)
+            if (!coefficients[i].isZero())
+                throw new UnsupportedOperationException("No integer value for " + this);
+        return coefficients[0].asInteger();
+    }
 }

--- a/src/main/java/de/upb/crypto/math/pairings/type3/bn/BarretoNaehrigBilinearGroupImpl.java
+++ b/src/main/java/de/upb/crypto/math/pairings/type3/bn/BarretoNaehrigBilinearGroupImpl.java
@@ -225,7 +225,8 @@ public class BarretoNaehrigBilinearGroupImpl implements BilinearGroupImpl {
     }
 
     /**
-     * This functions throws an exception because for type 3 pairings there is not efficient map H:G2->G1.
+     * This functions throws an exception because for type 3 pairings there is no efficient homomorphism
+     * {@code H : G2 -> G1}.
      */
     @Override
     public GroupHomomorphismImpl getHomomorphismG2toG1() {

--- a/src/main/java/de/upb/crypto/math/structures/bool/BooleanElement.java
+++ b/src/main/java/de/upb/crypto/math/structures/bool/BooleanElement.java
@@ -125,4 +125,9 @@ public class BooleanElement implements RingElement {
     public Representation getRepresentation() {
         return new ByteArrayRepresentation(new byte[] {(byte) (value ? 1 : 0)});
     }
+
+    @Override
+    public BigInteger asInteger() throws UnsupportedOperationException {
+        return value ? BigInteger.ONE : BigInteger.ZERO;
+    }
 }

--- a/src/main/java/de/upb/crypto/math/structures/cartesian/GroupElementVector.java
+++ b/src/main/java/de/upb/crypto/math/structures/cartesian/GroupElementVector.java
@@ -151,4 +151,9 @@ public class GroupElementVector extends Vector<GroupElement> implements Represen
         forEach(GroupElement::precomputePow);
         return this;
     }
+
+    public GroupElementVector precomputePow(int windowSize) {
+        forEach(g -> g.precomputePow(windowSize));
+        return this;
+    }
 }

--- a/src/main/java/de/upb/crypto/math/structures/cartesian/ProductGroupElement.java
+++ b/src/main/java/de/upb/crypto/math/structures/cartesian/ProductGroupElement.java
@@ -101,6 +101,10 @@ public class ProductGroupElement implements GroupElement {
         return accumulator;
     }
 
+    public GroupElementVector asVector() {
+        return new GroupElementVector(elems, true);
+    }
+
     @Override
     public Representation getRepresentation() {
         ListRepresentation repr = new ListRepresentation();

--- a/src/main/java/de/upb/crypto/math/structures/integers/IntegerElement.java
+++ b/src/main/java/de/upb/crypto/math/structures/integers/IntegerElement.java
@@ -16,7 +16,7 @@ import java.util.Objects;
  * An Integer (as an Element of {@link IntegerRing}).
  */
 public class IntegerElement implements RingElement {
-    private static IntegerRing ring = new IntegerRing();
+    private static final IntegerRing ring = new IntegerRing();
 
     @UniqueByteRepresented
     private final BigInteger v;
@@ -116,7 +116,7 @@ public class IntegerElement implements RingElement {
     }
 
     @Override
-    public BigInteger asExponent() throws UnsupportedOperationException {
+    public BigInteger asInteger() throws UnsupportedOperationException {
         return v;
     }
 }

--- a/src/main/java/de/upb/crypto/math/structures/integers/IntegerRing.java
+++ b/src/main/java/de/upb/crypto/math/structures/integers/IntegerRing.java
@@ -72,9 +72,8 @@ public class IntegerRing implements Ring {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        return o != null && getClass() == o.getClass();
+    public boolean equals(Object obj) {
+        return obj instanceof IntegerRing;
     }
 
     @Override

--- a/src/main/java/de/upb/crypto/math/structures/polynomial/PolynomialRing.java
+++ b/src/main/java/de/upb/crypto/math/structures/polynomial/PolynomialRing.java
@@ -145,7 +145,7 @@ public class PolynomialRing implements Ring {
         }
 
         public RingElement[] getCoefficients() {
-            return coefficients;
+            return Arrays.copyOf(coefficients, coefficients.length);
         }
 
         /**
@@ -492,6 +492,13 @@ public class PolynomialRing implements Ring {
             remainder = dividend;
 
             return new Polynomial[]{quotient, remainder};
+        }
+
+        @Override
+        public BigInteger asInteger() throws UnsupportedOperationException {
+            if (getDegree() > 0)
+                throw new UnsupportedOperationException("Not an integer: "+this);
+            return coefficients[0].asInteger();
         }
 
         @Override

--- a/src/main/java/de/upb/crypto/math/structures/zn/Zn.java
+++ b/src/main/java/de/upb/crypto/math/structures/zn/Zn.java
@@ -296,7 +296,7 @@ public class Zn implements Ring {
         }
 
         @Override
-        public BigInteger asExponent() throws UnsupportedOperationException {
+        public BigInteger asInteger() throws UnsupportedOperationException {
             return v;
         }
     }

--- a/src/test/java/de/upb/crypto/math/pairings/test/PairingTests.java
+++ b/src/test/java/de/upb/crypto/math/pairings/test/PairingTests.java
@@ -102,7 +102,7 @@ public class PairingTests {
         //Compute result using expression
         GroupElementExpression expr = pairing.getGT().expr();
         for (int i = 0; i < g.length; i++) {
-            expr = expr.op(pairing.expr(g[i], h[i]).pow(exp[i]));
+            expr = expr.op(pairing.applyExpr(g[i], h[i]).pow(exp[i]));
         }
         GroupElement resultExpr = expr.evaluate();
 
@@ -130,7 +130,7 @@ public class PairingTests {
         //Try nested expressions: e(g[i] * g[i+1], h[i])^2
         expr = pairing.getGT().expr();
         for (int i = 0; i + 1 < g.length; i += 2) {
-            expr = expr.opPow(pairing.expr(g[i].expr().op(g[i + 1]).pow(exp[i]), h[i].expr()), BigInteger.valueOf(2));
+            expr = expr.opPow(pairing.applyExpr(g[i].expr().op(g[i + 1]).pow(exp[i]), h[i].expr()), BigInteger.valueOf(2));
         }
         resultExpr = expr.evaluate();
         naive = pairing.getGT().getNeutralElement();


### PR DESCRIPTION
Among others:

- Variables (in the expression framework) are not necessarily named anymore. Also, `Variable` is now an interface, i.e. one can implement their own custom Variables (as done in the protocols lib).
- There is now an interface `Substitution` that replaces the `Function<String, Expression>` type. It's functionally identical in cases where you'd supply a lambda expression and has better readability in cases where some `clazz extends Substitution` has substitution functionality built-in
- Some renaming