### PR TITLE
New ability to concurrently evaluate bool exprs

### DIFF
--- a/src/main/java/de/upb/crypto/math/expressions/bool/BoolAndExpr.java
+++ b/src/main/java/de/upb/crypto/math/expressions/bool/BoolAndExpr.java
@@ -35,6 +35,27 @@ public class BoolAndExpr implements BooleanExpression {
     }
 
     @Override
+    public LazyBoolEvaluationResult evaluateLazy(Substitution substitutions) {
+        LazyBoolEvaluationResult lhs = this.lhs.evaluateLazy(substitutions);
+        LazyBoolEvaluationResult rhs = this.rhs.evaluateLazy(substitutions);
+        if (lhs.isResultKnown())
+            return lhs.getResult() ? rhs : LazyBoolEvaluationResult.FALSE;
+        if (rhs.isResultKnown())
+            return rhs.getResult() ? lhs : LazyBoolEvaluationResult.FALSE;
+        return new LazyBoolEvaluationResult() {
+            @Override
+            public boolean getResult() {
+                return lhs.getResult() && rhs.getResult();
+            }
+
+            @Override
+            boolean isResultKnown() {
+                return false;
+            }
+        };
+    }
+
+    @Override
     public void forEachChild(Consumer<Expression> action) {
         action.accept(lhs);
         action.accept(rhs);

--- a/src/main/java/de/upb/crypto/math/expressions/bool/BoolConstantExpr.java
+++ b/src/main/java/de/upb/crypto/math/expressions/bool/BoolConstantExpr.java
@@ -29,6 +29,11 @@ public class BoolConstantExpr implements BooleanExpression {
     }
 
     @Override
+    public LazyBoolEvaluationResult evaluateLazy(Substitution substitutions) {
+        return LazyBoolEvaluationResult.valueOf(value);
+    }
+
+    @Override
     public void forEachChild(Consumer<Expression> action) {
         //Nothing to do
     }

--- a/src/main/java/de/upb/crypto/math/expressions/bool/BoolEmptyExpr.java
+++ b/src/main/java/de/upb/crypto/math/expressions/bool/BoolEmptyExpr.java
@@ -1,5 +1,6 @@
 package de.upb.crypto.math.expressions.bool;
 
+import de.upb.crypto.math.expressions.EvaluationException;
 import de.upb.crypto.math.expressions.Expression;
 import de.upb.crypto.math.expressions.Substitution;
 
@@ -22,12 +23,17 @@ public class BoolEmptyExpr implements BooleanExpression {
 
     @Override
     public Boolean evaluate() {
-        throw new IllegalArgumentException("Cannot evaluate an empty expression.");
+        throw new EvaluationException(this, "Cannot evaluate an empty expression.");
     }
 
     @Override
     public Boolean evaluate(Substitution substitutions) {
         return evaluate();
+    }
+
+    @Override
+    public LazyBoolEvaluationResult evaluateLazy(Substitution substitutions) {
+        throw new EvaluationException(this, "Cannot evaluate an empty expression.");
     }
 
     @Override

--- a/src/main/java/de/upb/crypto/math/expressions/bool/BoolNotExpr.java
+++ b/src/main/java/de/upb/crypto/math/expressions/bool/BoolNotExpr.java
@@ -36,6 +36,24 @@ public class BoolNotExpr implements BooleanExpression {
     }
 
     @Override
+    public LazyBoolEvaluationResult evaluateLazy(Substitution substitutions) {
+        LazyBoolEvaluationResult childResult = child.evaluateLazy(substitutions);
+        if (childResult.isResultKnown())
+            return LazyBoolEvaluationResult.valueOf(!childResult.getResult());
+        return new LazyBoolEvaluationResult() {
+            @Override
+            public boolean getResult() {
+                return !childResult.getResult();
+            }
+
+            @Override
+            boolean isResultKnown() {
+                return false;
+            }
+        };
+    }
+
+    @Override
     public void forEachChild(Consumer<Expression> action) {
         action.accept(child);
     }

--- a/src/main/java/de/upb/crypto/math/expressions/bool/BoolOrExpr.java
+++ b/src/main/java/de/upb/crypto/math/expressions/bool/BoolOrExpr.java
@@ -49,6 +49,27 @@ public class BoolOrExpr implements BooleanExpression {
     }
 
     @Override
+    public LazyBoolEvaluationResult evaluateLazy(Substitution substitutions) {
+        LazyBoolEvaluationResult lhs = this.lhs.evaluateLazy(substitutions);
+        LazyBoolEvaluationResult rhs = this.rhs.evaluateLazy(substitutions);
+        if (lhs.isResultKnown())
+            return lhs.getResult() ? LazyBoolEvaluationResult.TRUE : rhs;
+        if (rhs.isResultKnown())
+            return rhs.getResult() ? LazyBoolEvaluationResult.TRUE : lhs;
+        return new LazyBoolEvaluationResult() {
+            @Override
+            public boolean getResult() {
+                return lhs.getResult() || rhs.getResult();
+            }
+
+            @Override
+            boolean isResultKnown() {
+                return false;
+            }
+        };
+    }
+
+    @Override
     public void forEachChild(Consumer<Expression> action) {
         action.accept(lhs);
         action.accept(rhs);

--- a/src/main/java/de/upb/crypto/math/expressions/bool/BoolVariableExpr.java
+++ b/src/main/java/de/upb/crypto/math/expressions/bool/BoolVariableExpr.java
@@ -35,4 +35,12 @@ public interface BoolVariableExpr extends VariableExpression, BooleanExpression 
             return (BooleanExpression) replacement;
         return this;
     }
+
+    @Override
+    default LazyBoolEvaluationResult evaluateLazy(Substitution substitutions) {
+        BooleanExpression substitution = (BooleanExpression) substitutions.getSubstitution(this);
+        if (substitution == null)
+            throw new EvaluationException(this, "Variable cannot be evaluated");
+        return substitution.evaluateLazy();
+    }
 }

--- a/src/main/java/de/upb/crypto/math/expressions/bool/BooleanExpression.java
+++ b/src/main/java/de/upb/crypto/math/expressions/bool/BooleanExpression.java
@@ -8,6 +8,9 @@ import de.upb.crypto.math.expressions.VariableExpression;
  * An {@link Expression} that evaluates to a {@code Boolean}.
  */
 public interface BooleanExpression extends Expression {
+    BoolConstantExpr TRUE = new BoolConstantExpr(true);
+    BoolConstantExpr FALSE = new BoolConstantExpr(false);
+
     @Override
     BooleanExpression substitute(Substitution substitutions);
 
@@ -28,6 +31,22 @@ public interface BooleanExpression extends Expression {
 
     @Override
     Boolean evaluate(Substitution substitutions);
+
+    /**
+     * Evaluates the result of this expression (with the given substitutions) concurrently in the background. <br>
+     * The result can be retrieved by calling getResult() on the return value.
+     */
+    LazyBoolEvaluationResult evaluateLazy(Substitution substitutions);
+
+    /**
+     * Evaluates the result of this expression concurrently in the background. Result can be retrieved
+     * by calling getResult() on the return value.<br>
+     * Use this for (potentially) more computationally expensive expressions.
+     */
+    default LazyBoolEvaluationResult evaluateLazy() {
+        return evaluateLazy(e -> null);
+    }
+
 
     /**
      * Applies a Boolean AND to this and the given Boolean expression.
@@ -51,5 +70,9 @@ public interface BooleanExpression extends Expression {
      */
     default BooleanExpression not() {
         return new BoolNotExpr(this);
+    }
+
+    static BooleanExpression valueOf(boolean bool) {
+        return bool ? TRUE : FALSE;
     }
 }

--- a/src/main/java/de/upb/crypto/math/expressions/bool/ExponentEqualityExpr.java
+++ b/src/main/java/de/upb/crypto/math/expressions/bool/ExponentEqualityExpr.java
@@ -37,6 +37,11 @@ public class ExponentEqualityExpr implements BooleanExpression {
     }
 
     @Override
+    public LazyBoolEvaluationResult evaluateLazy(Substitution substitution) {
+        return evaluate(substitution) ? LazyBoolEvaluationResult.TRUE : LazyBoolEvaluationResult.FALSE;
+    }
+
+    @Override
     public void forEachChild(Consumer<Expression> action) {
         action.accept(lhs);
         action.accept(rhs);

--- a/src/main/java/de/upb/crypto/math/expressions/bool/GroupEqualityExpr.java
+++ b/src/main/java/de/upb/crypto/math/expressions/bool/GroupEqualityExpr.java
@@ -4,6 +4,7 @@ import de.upb.crypto.math.expressions.Expression;
 import de.upb.crypto.math.expressions.Substitution;
 import de.upb.crypto.math.expressions.group.GroupElementExpression;
 import de.upb.crypto.math.structures.groups.Group;
+import de.upb.crypto.math.structures.groups.GroupElement;
 
 import java.util.function.Consumer;
 
@@ -55,8 +56,32 @@ public class GroupEqualityExpr implements BooleanExpression {
     }
 
     @Override
+    public LazyBoolEvaluationResult evaluateLazy(Substitution substitution) {
+        return new LazyGroupEqualityResult(lhs.evaluate(substitution), rhs.evaluate(substitution));
+    }
+
+    @Override
     public void forEachChild(Consumer<Expression> action) {
         action.accept(lhs);
         action.accept(rhs);
+    }
+
+    private static class LazyGroupEqualityResult extends LazyBoolEvaluationResult {
+        protected final GroupElement lhs, rhs;
+
+        public LazyGroupEqualityResult(GroupElement lhs, GroupElement rhs) {
+            this.lhs = lhs.compute();
+            this.rhs = rhs.compute();
+        }
+
+        @Override
+        public boolean getResult() {
+            return lhs.equals(rhs);
+        }
+
+        @Override
+        public boolean isResultKnown() {
+            return lhs.isComputed() && rhs.isComputed(); //already done (e.g., values have been computed before)
+        }
     }
 }

--- a/src/main/java/de/upb/crypto/math/expressions/bool/LazyBoolEvaluationResult.java
+++ b/src/main/java/de/upb/crypto/math/expressions/bool/LazyBoolEvaluationResult.java
@@ -1,0 +1,44 @@
+package de.upb.crypto.math.expressions.bool;
+
+/**
+ * Placeholder for the evaluation result of a BooleanExpression while it's being evaluated in the background.
+ */
+public abstract class LazyBoolEvaluationResult {
+    public static final LazyBoolEvaluationResult TRUE = new LazyBoolEvaluationResult() {
+        @Override
+        public boolean getResult() {
+            return true;
+        }
+
+        @Override
+        public boolean isResultKnown() {
+            return true;
+        }
+    };
+
+    public static final LazyBoolEvaluationResult FALSE = new LazyBoolEvaluationResult() {
+        @Override
+        public boolean getResult() {
+            return false;
+        }
+
+        @Override
+        public boolean isResultKnown() {
+            return true;
+        }
+    };
+
+    /**
+     * Returns the result of evaluation (call may block until it's been computed)
+     */
+    public abstract boolean getResult();
+
+    /**
+     * For optimization: returns true if getResult() will return basically immediately.
+     */
+    abstract boolean isResultKnown();
+
+    public static LazyBoolEvaluationResult valueOf(boolean bool) {
+        return bool ? TRUE : FALSE;
+    }
+}


### PR DESCRIPTION
Boolean expressions can now be evaluated concurrently. In particular, evaluation of boolean expressions with lots of unevaluated `LazyGroupElement`s should now be much faster.

The API may be slightly weird. There is no reason from the user's perspective as to why `evaluate` doesn't do all the fancy concurrency in the background and they should call `evaluateLazy` instead. The technical internal reason is that `BooleanExpression` is an interface and we cannot really prescribe a common protected method to the subclasses that says "start evaluating this in the background". 

I personally think it's fine. If anyone has a clever idea how to better implement this functionality, let me know. 